### PR TITLE
feat: use tolerations from values in ebs-csi-node daemonset

### DIFF
--- a/aws-ebs-csi-driver/templates/manifest.yaml
+++ b/aws-ebs-csi-driver/templates/manifest.yaml
@@ -342,9 +342,12 @@ spec:
         beta.kubernetes.io/os: linux
       hostNetwork: true
       priorityClassName: system-node-critical
+{{- with .Values.tolerations }}
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
+{{ toYaml . | indent 8 }}
+{{- end }}
       imagePullSecrets:
         - name: {{ .Values.imagePullSecrets | default "registry-dockerconfigjson" }}
       containers:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

This is a new feature.

**What is this PR about? / Why do we need it?**

For the driver to work on tainted nodes, the ebs-csi-node daemonset needs to put pods on these nodes. The tolerations value is already present in the chart `values.yaml`, this pull request actually use it in the template file `manifest.yaml`.

**What testing is done?** 

This has been tested in a live development k8s cluster.