### PR TITLE
Chart fixes

### DIFF
--- a/osc-bsu-csi-driver/Chart.yaml
+++ b/osc-bsu-csi-driver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v0.0.6beta"
+appVersion: "v0.0.8beta"
 name: osc-bsu-csi-driver
 description: A Helm chart for Outscale BSU CSI Driver
 version: 0.1.0

--- a/osc-bsu-csi-driver/Chart.yaml
+++ b/osc-bsu-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 appVersion: "v0.0.6beta"
-name: aws-ebs-csi-driver
-description: A Helm chart for AWS EBS CSI Driver
+name: osc-bsu-csi-driver
+description: A Helm chart for Outscale BSU CSI Driver
 version: v0.0.6beta
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/outscale-dev/osc-bsu-csi-driver

--- a/osc-bsu-csi-driver/Chart.yaml
+++ b/osc-bsu-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.0.6beta"
 name: osc-bsu-csi-driver
 description: A Helm chart for Outscale BSU CSI Driver
-version: v0.0.6beta
+version: 0.1.0
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/outscale-dev/osc-bsu-csi-driver
 sources:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**

This bugfix PR should fix the following chart issues:
* Chart naming (it did not get renamed with its directory, and according to Helm docs these should match).
* Chart versioning (Helm is starting to get very picky about it being SemVer, starting 3.5.2).

**What is this PR about? / Why do we need it?**

We update Chart.yaml to fix the Chart metadata. This is mainly useful currently when using the GitHub repository as a Helm repository (with the git+https:// scheme), but we start seeing SemVer version issue with Helm 3.5.2 even when using "helm template" directly.

* Naming update to `osc-bsu-csi-driver`: This permits fixing the output of "helm search repo" to actually have the correct name.

* Chart version is updated to a separate version scheme that the driver one; several reasons for this one.
  * I feel this is preferable because it's a separate product from the driver itself; we may(should) not have to bump the chart version every time we bump the driver version.
  * The closest SemVer match of v0.0.8beta is 0.0.8-beta, which is still not v0.0.8beta.
  * Helm has a default of not finding beta versions when doing `helm search repo` or `helm install repo/chart` and this is not very intuitive when we add the repo and then don't find a chart to install because 0.0.8-beta fails to match.

**What testing is done?** 

No automated testing added.
Manually tested against helm and helmfile (helm template, helm repo add, ..).