### PR TITLE
Reduce default verbosity, provide Helm knob to tune.

### DIFF
--- a/osc-bsu-csi-driver/Chart.yaml
+++ b/osc-bsu-csi-driver/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.0.8beta"
 name: osc-bsu-csi-driver
 description: A Helm chart for Outscale BSU CSI Driver
-version: 0.1.0
+version: 0.1.1
 kubeVersion: ">=1.14.0-0"
 home: https://github.com/outscale-dev/osc-bsu-csi-driver
 sources:

--- a/osc-bsu-csi-driver/templates/controller.yaml
+++ b/osc-bsu-csi-driver/templates/controller.yaml
@@ -58,7 +58,7 @@ spec:
             - --k8s-tag-cluster-id={{ .Values.k8sTagClusterId }}
             {{- end }}
             - --logtostderr
-            - --v=10
+            - --v={{ .Values.verbosity }}
           env:
             - name: CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
@@ -106,7 +106,7 @@ spec:
           image: {{ printf "%s:%s" .Values.sidecars.provisionerImage.repository .Values.sidecars.provisionerImage.tag }}
           args:
             - --csi-address=$(ADDRESS)
-            - --v=10
+            - --v={{ .Values.verbosity }}
             {{- if .Values.enableVolumeScheduling }}
             - --feature-gates=Topology=true
             {{- end}}
@@ -128,7 +128,7 @@ spec:
           image: {{ printf "%s:%s" .Values.sidecars.attacherImage.repository .Values.sidecars.attacherImage.tag }}
           args:
             - --csi-address=$(ADDRESS)
-            - --v=10
+            - --v={{ .Values.verbosity }}
             - --leader-election=true
           env:
             - name: ADDRESS
@@ -145,6 +145,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --leader-election=true
+            - --v={{ .Values.verbosity }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -161,7 +162,7 @@ spec:
           imagePullPolicy: Always
           args:
             - --csi-address=$(ADDRESS)
-            - --v=10
+            - --v={{ .Values.verbosity }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/osc-bsu-csi-driver/templates/node.yaml
+++ b/osc-bsu-csi-driver/templates/node.yaml
@@ -52,7 +52,7 @@ spec:
             - node
             - --endpoint=$(CSI_ENDPOINT)
             - --logtostderr
-            - --v=10
+            - --v={{ .Values.verbosity }}
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
@@ -90,7 +90,7 @@ spec:
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
-            - --v=10
+            - --v={{ .Values.verbosity }}
           lifecycle:
             preStop:
               exec:

--- a/osc-bsu-csi-driver/templates/statefulset.yaml
+++ b/osc-bsu-csi-driver/templates/statefulset.yaml
@@ -25,6 +25,6 @@ spec:
         - name: snapshot-controller
           image: quay.io/k8scsi/snapshot-controller:v2.1.1
           args:
-            - --v=10
+            - --v={{ .Values.verbosity }}
             - --leader-election=false
 {{- end }}

--- a/osc-bsu-csi-driver/values.yaml
+++ b/osc-bsu-csi-driver/values.yaml
@@ -92,6 +92,11 @@ k8sTagClusterId: ""
 # region: us-east-1
 region: ""
 
+# Set the verbosity of the various components of the BSU CSI Driver.
+# Please be aware that sensitive information may be present in high
+# verbosity modes.
+verbosity: 2
+
 node:
   podAnnotations: {}
   tolerateAllTaints: true


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
This PR is an enhancement to the Helm chart.

**What is this PR about? / Why do we need it?**
This PR fixes issue described at #10 by adding a knob to tune verbosity at containers that support it.

**What testing is done?** 
The feature was manually tested on a 1.18.16 Kubernetes cluster, and with Helm 3.5.2.