### PR TITLE
add automatic alert and bump versions bot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "OSC-MIGRATION"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Signed-off-by: Ubuntu <outscale@ip-10-9-21-69.eu-west-2.compute.internal>

**Is this a bug fix or adding new feature?**

**What is this PR about? / Why do we need it?**

**What testing is done?** 
