### PR TITLE
CVE libexpat

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -73,3 +73,7 @@ CVE-2022-22827
 CVE-2021-33560
 # https://security-tracker.debian.org/tracker/CVE-2020-16156
 CVE-2020-16156
+# https://security-tracker.debian.org/tracker/CVE-2022-23852
+CVE-2022-23852
+# https://security-tracker.debian.org/tracker/CVE-2022-23990
+CVE-2022-23990


### PR DESCRIPTION
[CVE-2022-23852](https://security-tracker.debian.org/tracker/CVE-2022-23852)
[CVE-2022-23990](https://security-tracker.debian.org/tracker/CVE-2022-23990)