### PR TITLE
Update Docker image for CVE fixes

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -57,3 +57,5 @@ CVE-2021-3999
 CVE-2021-33560
 # https://security-tracker.debian.org/tracker/CVE-2020-16156
 CVE-2020-16156
+# https://security-tracker.debian.org/tracker/CVE-2022-0391
+CVE-2022-0391

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-20220125
+FROM debian:bullseye-20220228
 RUN apt-get -y update && \
     apt-get -y install libc-bin=2.31-13+deb11u2 \
                        ca-certificates=20210119 \


### PR DESCRIPTION
- To fix : CVE-2022-25235, CVE-2022-25236, CVE-2022-25315, CVE-2022-25314
- Ignore this CVE because it is not yet fixed: CVE-2022-0391
