### PR TITLE
Update Docker images

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -59,3 +59,5 @@ CVE-2021-33560
 CVE-2020-16156
 # https://security-tracker.debian.org/tracker/CVE-2022-0391
 CVE-2022-0391
+# https://security-tracker.debian.org/tracker/CVE-2021-3737
+CVE-2021-3737

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-20220228
+FROM debian:bullseye-20220316
 RUN apt-get -y update && \
     apt-get -y install libc-bin=2.31-13+deb11u2 \
                        ca-certificates=20210119 \


### PR DESCRIPTION
- Fixes cves: CVE-2022-0778
- Ignore for now: CVE-2021-3737