### PR TITLE
Fixed gzip CVE (CVE-2022-1271)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -53,8 +53,6 @@ CVE-2022-0391
 CVE-2021-3737
 # https://security-tracker.debian.org/tracker/CVE-2018-25032
 CVE-2018-25032
-# https://security-tracker.debian.org/tracker/CVE-2022-1271
-CVE-2022-1271
 # https://security-tracker.debian.org/tracker/CVE-2022-1304
 CVE-2022-1304
 # https://security-tracker.debian.org/tracker/CVE-2015-20107

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,8 @@ RUN apt-get -y update && \
                        util-linux=2.36.1-8+deb11u1 \
                        udev=247.3-7 \
                        xfsprogs=5.10.0-4 \
+                       gzip=1.10-4+deb11u1 \
+                       liblzma5=5.2.5-2.1~deb11u1 \
                        --no-install-recommends && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
- upgrade GZIP and liblzma5
- remove the CVE from trivy-ignore