### PR TITLE
Skip CI when no important files are modified

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,24 @@ on:
   pull_request:
     branches:
       - OSC-MIGRATION
+    paths:
+      - "**.go"
+      - "Dockerfile"
+      - ".trivyignore"
+      - "Makefile"
+      - "go.*"
+      - ".github/workflows/build.yml"
+      - "!tests/**"
   push:
     branches: [ OSC-MIGRATION ]
+    paths:
+      - "**.go"
+      - "Dockerfile"
+      - ".trivyignore"
+      - "Makefile"
+      - "go.*"
+      - ".github/workflows/build.yml"
+      - "!tests/**"
 jobs:
   Build:
     if: github.repository == 'outscale-dev/osc-bsu-csi-driver'

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -4,8 +4,24 @@ on:
   pull_request_target:
     branches:
       - OSC-MIGRATION
+    paths:
+      - "**.go"
+      - "Dockerfile"
+      - ".trivyignore"
+      - "Makefile"
+      - "go.*"
+      - "osc-bsu-csi-driver/**.yaml"
+      - ".github/workflows/e2e_test.yml"
   push:
     branches: [ OSC-MIGRATION ]
+    paths:
+      - "**.go"
+      - "Dockerfile"
+      - ".trivyignore"
+      - "Makefile"
+      - "go.*"
+      - "osc-bsu-csi-driver/**.yaml"
+      - ".github/workflows/e2e_test.yml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- Build CI action needs to be execute only when source file, docker file
  are modified
- e2e tests needs to be modified only when source file, docker file and
  tests files are modified
