### PR TITLE
Remove metadata svc in controller

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -28,11 +28,7 @@ import (
 	"github.com/antihax/optional"
 	"github.com/outscale/osc-sdk-go/osc"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/ec2metadata"
-	"github.com/aws/aws-sdk-go/aws/endpoints"
-	"github.com/aws/aws-sdk-go/aws/session"
 	dm "github.com/outscale-dev/osc-bsu-csi-driver/pkg/cloud/devicemanager"
 	"github.com/outscale-dev/osc-bsu-csi-driver/pkg/util"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -287,14 +283,6 @@ func newOscCloud(region string) (Cloud, error) {
 		dm:     dm.NewDeviceManager(),
 		client: client,
 	}, nil
-}
-
-func newEC2MetadataSvc() *ec2metadata.EC2Metadata {
-
-	sess := session.Must(session.NewSession(&aws.Config{
-		EndpointResolver: endpoints.ResolverFunc(util.OscSetupMetadataResolver()),
-	}))
-	return ec2metadata.New(sess)
 }
 
 func IsNilDisk(disk Disk) bool {

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -864,11 +864,6 @@ func newCloud(mockOscInterface OscInterface) *cloud {
 		region: "test-region",
 		dm:     dm.NewDeviceManager(),
 		client: mockOscInterface,
-		metadata: &Metadata{
-			InstanceID:       "test-instance",
-			Region:           "test-region",
-			AvailabilityZone: defaultZone,
-		},
 	}
 }
 

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -184,6 +184,14 @@ func TestCreateDisk(t *testing.T) {
 				}
 			}
 
+			if tc.diskOptions.AvailabilityZone == "" {
+				mockOscInterface.EXPECT().ReadSubregions(gomock.Eq(ctx), gomock.Any()).Return(osc.ReadSubregionsResponse{Subregions: []osc.Subregion{
+					{
+						SubregionName: defaultZone,
+					},
+				}}, nil, nil)
+			}
+
 			disk, err := c.CreateDisk(ctx, tc.volumeName, tc.diskOptions)
 			if err != nil {
 				if tc.expErr == nil {


### PR DESCRIPTION
For some clusters (like OpenShift 4.X), the meta-data server is not reachable, here is a PR to partially avoid requiring an access to meta-data server.

The controller only needs the meta-data server in order to retrieve the region of the cluster to create Volume in the good region.

Now, if you provide the region during the deployment with `--region=OSC_REGION`, the controller pod will not require this access.

/!\ Note that the node pod still needs this access to retrieve its VmId.