### PR TITLE
Set the version of helm to use in e2e - 0.X

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -39,7 +39,9 @@ jobs:
         repository: 'outscale-dev/osc-k8s-rke-cluster'
         path: "set-up-rke-cluster"
     - uses: azure/setup-kubectl@v2.0
-    - uses: azure/setup-helm@v1
+    - uses: azure/setup-helm@v3
+      with:
+        version: v3.10.1
     - uses: actions/setup-go@v2
       with:
         go-version: '1.17'


### PR DESCRIPTION
The first version of `setup-helm` does not retrieve the latest version of `helm` and CI fails.
