### PR TITLE
⚡️ perfs: improve snapshot readiness delay

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       uses: golangci/golangci-lint-action@v8
       with:
         version: v2.1.6
-        args: --timeout=600s
+        args: --timeout=300s
         only-new-issues: true
   unit-test:
     runs-on: ubuntu-22.04

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -546,6 +546,7 @@ func TestCreateSnapshot(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, tc.expSnapshot.SourceVolumeID, snapshot.SourceVolumeID)
+				assert.True(t, snapshot.IsReadyToUse())
 			}
 
 			mockCtrl.Finish()


### PR DESCRIPTION
The readiness status was not reported after CreateSnapshot and the CSI controller had to retry once to get the correct status.