### PR TITLE
🐛 fix(helm): use image.pullPolicy on all sidecars

### DIFF
--- a/osc-bsu-csi-driver/templates/controller.yaml
+++ b/osc-bsu-csi-driver/templates/controller.yaml
@@ -344,7 +344,7 @@ spec:
         {{- if .Values.enableVolumeResizing }}
         - name: csi-resizer
           image: {{ printf "%s:%s" .Values.sidecars.resizerImage.repository .Values.sidecars.resizerImage.tag }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             {{- if not (regexMatch "(-retry-interval-max)" (join " " .Values.sidecars.resizerImage.additionalArgs)) }}
             - --retry-interval-max=5m


### PR DESCRIPTION
## Description

The resizer sidecar image did not use the configured `image.pullPolicy`.

Fixes: #1008

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
