### PR TITLE
👷 build: no git on build env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,8 @@ PKG := github.com/outscale/osc-bsu-csi-driver
 IMAGE := outscale/osc-bsu-csi-driver
 IMAGE_TAG ?= $(shell git describe --tags --always --dirty)
 VERSION ?= ${IMAGE_TAG}
-GIT_COMMIT ?= $(shell git rev-parse HEAD)
 BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-LDFLAGS ?= "-s -w -X ${PKG}/pkg/util.driverVersion=${VERSION} -X ${PKG}/pkg/util.gitCommit=${GIT_COMMIT} -X ${PKG}/pkg/util.buildDate=${BUILD_DATE}"
+LDFLAGS ?= "-s -w -X ${PKG}/pkg/util.driverVersion=${VERSION} -X ${PKG}/pkg/util.buildDate=${BUILD_DATE}"
 GO111MODULE := on
 GOPROXY := direct
 TRIVY_IMAGE := aquasec/trivy:0.30.0

--- a/pkg/util/version.go
+++ b/pkg/util/version.go
@@ -25,13 +25,11 @@ import (
 // These are set during build time via -ldflags
 var (
 	driverVersion string
-	gitCommit     string
 	buildDate     string
 )
 
 type VersionInfo struct {
 	DriverVersion string `json:"driverVersion"`
-	GitCommit     string `json:"gitCommit"`
 	BuildDate     string `json:"buildDate"`
 	GoVersion     string `json:"goVersion"`
 	Compiler      string `json:"compiler"`
@@ -41,7 +39,6 @@ type VersionInfo struct {
 func GetVersion() VersionInfo {
 	return VersionInfo{
 		DriverVersion: driverVersion,
-		GitCommit:     gitCommit,
 		BuildDate:     buildDate,
 		GoVersion:     runtime.Version(),
 		Compiler:      runtime.Compiler,

--- a/pkg/util/version_test.go
+++ b/pkg/util/version_test.go
@@ -28,7 +28,6 @@ func TestGetVersion(t *testing.T) {
 
 	expected := VersionInfo{
 		DriverVersion: "",
-		GitCommit:     "",
 		BuildDate:     "",
 		GoVersion:     runtime.Version(),
 		Compiler:      runtime.Compiler,
@@ -48,7 +47,6 @@ func TestGetVersionJSON(t *testing.T) {
 
 	expected := fmt.Sprintf(`{
   "driverVersion": "",
-  "gitCommit": "",
   "buildDate": "",
   "goVersion": "%s",
   "compiler": "%s",


### PR DESCRIPTION
## Description

As the .git dir is not copied to the build env, it has no access to the current git rev.

This PR removes the gitCommit computation, removing some build errors.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [x] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [x] Integration tests
- [ ] Not tested yet


## Checklist

* [x] I have followed the [Contributing Guidelines](CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
