### PR TITLE
⚡️ perfs: batch Read calls for all snapshot/volumes being processed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     - name: 🔎 golangci-lint
       uses: golangci/golangci-lint-action@v8
       with:
-        version: v2.1.6
+        version: v2.6.0
         args: --timeout=300s
         only-new-issues: true
   unit-test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GOLANG_IMAGE_TAG=1.24.7-bookworm
+ARG GOLANG_IMAGE_TAG=1.25.3-bookworm
 # Tools are taken from Debian 12
 ARG TOOLS_IMAGE_TAG=12
 # Distroless debug is used to get a busybox shell

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/outscale/osc-bsu-csi-driver
 
-go 1.23.7
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go v1.55.7

--- a/pkg/cloud/watcher.go
+++ b/pkg/cloud/watcher.go
@@ -1,0 +1,167 @@
+package cloud
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	osc "github.com/outscale/osc-sdk-go/v2"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+)
+
+type result[T any] struct {
+	ok  *T
+	err error
+}
+
+func resultOk[T any](t *T) result[T] {
+	return result[T]{ok: t}
+}
+
+func resultError[T any](err error) result[T] {
+	return result[T]{err: err}
+}
+
+type watcher[T any] struct {
+	id    string
+	until func(r *T) (ok bool, err error)
+	resp  chan result[T]
+}
+
+type ResourceWatcher[T any] struct {
+	interval time.Duration
+	refresh  func(ctx context.Context, ids []string) ([]T, error)
+
+	in       chan watcher[T]
+	watchers map[string]watcher[T]
+}
+
+func NewResourceWatcher[T any](interval time.Duration,
+	refresh func(ctx context.Context, ids []string) ([]T, error)) *ResourceWatcher[T] {
+	return &ResourceWatcher[T]{
+		interval: interval,
+		refresh:  refresh,
+
+		in:       make(chan watcher[T]),
+		watchers: make(map[string]watcher[T]),
+	}
+}
+
+func NewSnapshotWatcher(interval time.Duration, client OscInterface) *ResourceWatcher[osc.Snapshot] {
+	return NewResourceWatcher(interval, func(ctx context.Context, ids []string) ([]osc.Snapshot, error) {
+		req := osc.ReadSnapshotsRequest{
+			Filters: &osc.FiltersSnapshot{
+				SnapshotIds: &ids,
+			},
+			ResultsPerPage: ptr.To(int32(len(ids))), //nolint:gosec
+		}
+		resp, httpRes, err := client.ReadSnapshots(ctx, req)
+		logAPICall(ctx, "ReadSnapshots", req, resp, httpRes, err)
+		if err != nil {
+			return nil, fmt.Errorf("read snapshots: %w", err)
+		}
+		rsnaps := resp.GetSnapshots()
+		snaps := make([]osc.Snapshot, len(rsnaps))
+		for i := range snaps {
+			id := ids[i]
+			j := slices.IndexFunc(rsnaps, func(snap osc.Snapshot) bool { return snap.GetSnapshotId() == id })
+			if j >= 0 {
+				snaps[i] = rsnaps[j]
+			}
+		}
+		return snaps, nil
+	})
+}
+
+func NewVolumeWatcher(interval time.Duration, client OscInterface) *ResourceWatcher[osc.Volume] {
+	return NewResourceWatcher(interval, func(ctx context.Context, ids []string) ([]osc.Volume, error) {
+		req := osc.ReadVolumesRequest{
+			Filters: &osc.FiltersVolume{
+				VolumeIds: &ids,
+			},
+			ResultsPerPage: ptr.To(int32(len(ids))), //nolint:gosec
+		}
+		resp, httpRes, err := client.ReadVolumes(ctx, req)
+		logAPICall(ctx, "ReadVolumes", req, resp, httpRes, err)
+		if err != nil {
+			return nil, fmt.Errorf("read volumes: %w", err)
+		}
+		rvols := resp.GetVolumes()
+		vols := make([]osc.Volume, len(rvols))
+		for i := range vols {
+			id := ids[i]
+			j := slices.IndexFunc(rvols, func(vol osc.Volume) bool { return vol.GetVolumeId() == id })
+			if j >= 0 {
+				vols[i] = rvols[j]
+			}
+
+		}
+		return vols, nil
+	})
+}
+
+func (sw *ResourceWatcher[T]) Run(ctx context.Context) {
+	logger := klog.FromContext(ctx)
+	t := time.NewTicker(sw.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case in := <-sw.in:
+			sw.watchers[in.id] = in
+		case <-t.C:
+			if len(sw.watchers) == 0 {
+				continue
+			}
+			ids := slices.Collect(maps.Keys(sw.watchers))
+			logger.V(5).Info("Watching resources", "count", len(ids))
+			rsrcs, err := sw.refresh(ctx, ids)
+			if err != nil {
+				logger.V(3).Error(err, "unable to check statuses")
+				continue
+			}
+			for i, rsrc := range rsrcs {
+				w, found := sw.watchers[ids[i]]
+				if !found { // should not occur
+					continue
+				}
+				ok, err := w.until(&rsrc)
+				switch {
+				case ok:
+					logger.V(5).Info("Resource is ok", "id", ids[i])
+					w.resp <- resultOk(&rsrc)
+					delete(sw.watchers, ids[i])
+					close(w.resp)
+				case err != nil:
+					logger.V(5).Info("Resource is in error", "id", ids[i])
+					w.resp <- resultError[T](err)
+					delete(sw.watchers, ids[i])
+					close(w.resp)
+				default:
+					logger.V(5).Info("Resource is not ready", "id", ids[i])
+				}
+			}
+		}
+	}
+}
+
+func (sw *ResourceWatcher[T]) WaitUntil(ctx context.Context, id string, until func(r *T) (ok bool, err error)) (r *T, err error) {
+	logger := klog.FromContext(ctx)
+	start := time.Now()
+	defer func() {
+		logger.V(4).Info("End of wait", "success", err == nil, "duration", time.Since(start))
+	}()
+	resp := make(chan result[T], 1)
+	w := watcher[T]{id: id, until: until, resp: resp}
+	sw.in <- w
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-w.resp:
+		return res.ok, res.err
+	}
+}

--- a/pkg/cloud/watcher_test.go
+++ b/pkg/cloud/watcher_test.go
@@ -1,0 +1,126 @@
+package cloud_test
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/outscale/osc-bsu-csi-driver/pkg/cloud"
+	"github.com/outscale/osc-bsu-csi-driver/pkg/cloud/mocks"
+	osc "github.com/outscale/osc-sdk-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"k8s.io/utils/ptr"
+)
+
+func TestResourceWatcher_Volumes(t *testing.T) {
+	t.Run("When concurrent calls are made, the right status is returned to the right volume", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockOscInterface := mocks.NewMockOscInterface(mockCtrl)
+		mockOscInterface.EXPECT().ReadVolumes(gomock.Any(), gomock.Cond(func(req osc.ReadVolumesRequest) bool {
+			return len(*req.Filters.VolumeIds) == 4
+		})).Return(osc.ReadVolumesResponse{Volumes: &[]osc.Volume{
+			{VolumeId: ptr.To("id-error"), State: ptr.To("error")},
+			{VolumeId: ptr.To("id-ready"), State: ptr.To("ready")},
+			{VolumeId: ptr.To("id-attached"), State: ptr.To("attached")},
+			{VolumeId: ptr.To("id-detached"), State: ptr.To("detached")},
+		}}, nil, nil).MinTimes(1)
+
+		rw := cloud.NewVolumeWatcher(time.Second, mockOscInterface)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		go rw.Run(ctx)
+
+		wg := sync.WaitGroup{}
+		for _, state := range []string{"ready", "detached", "attached", "error"} {
+			wg.Go(func() {
+				time.Sleep(time.Duration(rand.IntN(100)) * time.Millisecond)
+				v, err := rw.WaitUntil(ctx, "id-"+state, func(v *osc.Volume) (bool, error) {
+					if *v.State != state {
+						return false, errors.New("invalid state")
+					}
+					return true, nil
+				})
+				require.NoError(t, err)
+				assert.Equal(t, "id-"+state, v.GetVolumeId())
+				assert.Equal(t, state, v.GetState())
+			})
+		}
+		wg.Wait()
+	})
+	t.Run("Errors are returned", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockOscInterface := mocks.NewMockOscInterface(mockCtrl)
+		mockOscInterface.EXPECT().ReadVolumes(gomock.Any(), gomock.Any()).Return(osc.ReadVolumesResponse{Volumes: &[]osc.Volume{
+			{VolumeId: ptr.To("id-error"), State: ptr.To("error")},
+		}}, nil, nil).MinTimes(1)
+
+		rw := cloud.NewVolumeWatcher(time.Second, mockOscInterface)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		go rw.Run(ctx)
+
+		_, err := rw.WaitUntil(ctx, "id-error", func(v *osc.Volume) (bool, error) {
+			return false, errors.New("error")
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestResourceWatcher_Snapshots(t *testing.T) {
+	t.Run("When concurrent calls are made, the right status is returned to the right snapshot", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockOscInterface := mocks.NewMockOscInterface(mockCtrl)
+		mockOscInterface.EXPECT().ReadSnapshots(gomock.Any(), gomock.Cond(func(req osc.ReadSnapshotsRequest) bool {
+			return len(*req.Filters.SnapshotIds) == 4
+		})).Return(osc.ReadSnapshotsResponse{Snapshots: &[]osc.Snapshot{
+			{SnapshotId: ptr.To("id-error"), State: ptr.To("error")},
+			{SnapshotId: ptr.To("id-ready"), State: ptr.To("ready")},
+			{SnapshotId: ptr.To("id-attached"), State: ptr.To("attached")},
+			{SnapshotId: ptr.To("id-detached"), State: ptr.To("detached")},
+		}}, nil, nil).MinTimes(1)
+
+		rw := cloud.NewSnapshotWatcher(time.Second, mockOscInterface)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		go rw.Run(ctx)
+
+		wg := sync.WaitGroup{}
+		for _, state := range []string{"ready", "detached", "attached", "error"} {
+			wg.Go(func() {
+				time.Sleep(time.Duration(rand.IntN(100)) * time.Millisecond)
+				s, err := rw.WaitUntil(ctx, "id-"+state, func(v *osc.Snapshot) (bool, error) {
+					if *v.State != state {
+						return false, errors.New("invalid state")
+					}
+					return true, nil
+				})
+				require.NoError(t, err)
+				assert.Equal(t, "id-"+state, s.GetSnapshotId())
+				assert.Equal(t, state, s.GetState())
+			})
+		}
+		wg.Wait()
+	})
+	t.Run("Errors are returned", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		mockOscInterface := mocks.NewMockOscInterface(mockCtrl)
+		mockOscInterface.EXPECT().ReadSnapshots(gomock.Any(), gomock.Any()).Return(osc.ReadSnapshotsResponse{Snapshots: &[]osc.Snapshot{
+			{SnapshotId: ptr.To("id-error"), State: ptr.To("error")},
+		}}, nil, nil).MinTimes(1)
+
+		rw := cloud.NewSnapshotWatcher(time.Second, mockOscInterface)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		go rw.Run(ctx)
+
+		_, err := rw.WaitUntil(ctx, "id-error", func(v *osc.Snapshot) (bool, error) {
+			return false, errors.New("error")
+		})
+		require.Error(t, err)
+	})
+}

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -92,6 +92,13 @@ func newControllerService(driverOptions *DriverOptions) controllerService {
 	}
 }
 
+func (c *controllerService) Start(ctx context.Context) {
+	if c.cloud == nil {
+		return
+	}
+	c.cloud.Start(ctx)
+}
+
 func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	volName := req.GetName()
 	if volName == "" {

--- a/pkg/driver/mocks/mock_cloud.go
+++ b/pkg/driver/mocks/mock_cloud.go
@@ -234,6 +234,18 @@ func (mr *MockCloudMockRecorder) ResizeDisk(ctx, volumeID, reqSize any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeDisk", reflect.TypeOf((*MockCloud)(nil).ResizeDisk), ctx, volumeID, reqSize)
 }
 
+// Start mocks base method.
+func (m *MockCloud) Start(ctx context.Context) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Start", ctx)
+}
+
+// Start indicates an expected call of Start.
+func (mr *MockCloudMockRecorder) Start(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockCloud)(nil).Start), ctx)
+}
+
 // UpdateDisk mocks base method.
 func (m *MockCloud) UpdateDisk(ctx context.Context, volumeID, volumeType string, iopsPerGB int32) error {
 	m.ctrl.T.Helper()

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -132,6 +132,8 @@ func newFakeCloudProvider() *fakeCloudProvider {
 	}
 }
 
+func (c *fakeCloudProvider) Start(ctx context.Context) {}
+
 func (c *fakeCloudProvider) CreateDisk(ctx context.Context, volumeName string, diskOptions *cloud.DiskOptions) (cloud.Disk, error) {
 	if len(diskOptions.SnapshotID) > 0 {
 		if _, ok := c.snapshots[diskOptions.SnapshotID]; !ok {


### PR DESCRIPTION
## Description

The current drivers makes a lot of ReadVolumes/ReadSnapshots calls.

To avoid being throttled, Read calls for all Volumes/Snapshots being processed are batched in a single query.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [x] Other (specify): performance

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
