### PR TITLE
👷 ci(trivy): disable scanning of CSI binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ trivy-scan:
 			--exit-code 1 \
 			--severity="HIGH,CRITICAL" \
 			--ignorefile /root/.trivyignore \
-			--security-checks vuln \
+			--skip-files "/bin/osc-bsu-csi-driver" \
 			--format sarif -o /root/.trivyscan/report.sarif \
 			$(IMAGE):$(IMAGE_TAG)
 


### PR DESCRIPTION
## Description

Disable scanning of binary, as it reports many false positives. Dependabot does the same job, with the possibility of Dismissing false positives.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [x] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
