### PR TITLE
🔧 helm: snapshotter tuning, raise timeout for all

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -1,6 +1,6 @@
 # osc-bsu-csi-driver
 
-![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![AppVersion: v1.7.0](https://img.shields.io/badge/AppVersion-v1.7.0-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![AppVersion: v1.8.0](https://img.shields.io/badge/AppVersion-v1.8.0-informational?style=flat-square)
 
 A Helm chart for the Outscale BSU CSI Driver
 
@@ -26,7 +26,7 @@ Kubernetes: `>=1.20`
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity settings |
 | backoff.duration | string | `"750ms"` | Initial duraction of backoff |
-| backoff.factor | string | `"1.4"` | Factor multiplied by Duration for each iteration |
+| backoff.factor | string | `"1.6"` | Factor multiplied by Duration for each iteration |
 | backoff.steps | string | `"3"` | Remaining number of iterations in which the duration parameter may change |
 | caBundle.key | string | `""` | Entry key in secret used to store additional certificates authorities |
 | caBundle.name | string | `""` | Secret name containing additional certificates authorities |
@@ -47,7 +47,7 @@ Kubernetes: `>=1.20`
 | httpsProxy | string | `""` | Value used to create environment variable HTTPS_PROXY |
 | image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | image.repository | string | `"outscale/osc-bsu-csi-driver"` | Container image to use |
-| image.tag | string | `"v1.7.0"` | Container image tag to deploy |
+| image.tag | string | `"v1.8.0"` | Container image tag to deploy |
 | imagePullSecrets | list | `[]` | Specify image pull secrets |
 | maxBsuVolumes | string | `""` | Maximum number of volumes that can be attached to a single node, autocomputed by default (see [Docs](https://docs.outscale.com/en/userguide/About-Volumes.html)) |
 | nameOverride | string | `""` | Override name of the app (instead of `osc-bsu-csi-driver`) |
@@ -134,7 +134,7 @@ Kubernetes: `>=1.20`
 | sidecars.snapshotterImage.securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | sidecars.snapshotterImage.securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | sidecars.snapshotterImage.tag | string | `"v8.3.0"` |  |
-| timeout | string | `"60s"` | Timeout for sidecars |
+| timeout | string | `"120s"` | Timeout for sidecars |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoExecute","operator":"Exists","tolerationSeconds":300}]` | Pod tolerations |
 | updateStrategy | object | `{"type":"RollingUpdate"}` | Controller deployment update strategy. |
 | verbosity | int | `3` | Verbosity level of the plugin |

--- a/osc-bsu-csi-driver/Chart.yaml
+++ b/osc-bsu-csi-driver/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "v1.7.0"
+appVersion: "v1.8.0"
 name: osc-bsu-csi-driver
 description: A Helm chart for the Outscale BSU CSI Driver
-version: 1.9.0
+version: 1.10.0
 kubeVersion: ">=1.20"
 home: https://github.com/outscale/osc-bsu-csi-driver
 sources:

--- a/osc-bsu-csi-driver/helm_test.go
+++ b/osc-bsu-csi-driver/helm_test.go
@@ -95,7 +95,7 @@ func TestHelmTemplate_Deployment(t *testing.T) {
 		assert.Equal(t, int32(2), *dep.Spec.Replicas)
 		require.Len(t, dep.Spec.Template.Spec.Containers, 6)
 		manager := dep.Spec.Template.Spec.Containers[0]
-		assert.Equal(t, "outscale/osc-bsu-csi-driver:v1.7.0", manager.Image)
+		assert.Equal(t, "outscale/osc-bsu-csi-driver:v1.8.0", manager.Image)
 		assert.Equal(t, []string{
 			"controller",
 			"--endpoint=$(CSI_ENDPOINT)",
@@ -124,7 +124,7 @@ func TestHelmTemplate_Deployment(t *testing.T) {
 			}},
 			{Name: "OSC_REGION", Value: "eu-west2"},
 			{Name: "BACKOFF_DURATION", Value: "750ms"},
-			{Name: "BACKOFF_FACTOR", Value: "1.4"},
+			{Name: "BACKOFF_FACTOR", Value: "1.6"},
 			{Name: "BACKOFF_STEPS", Value: "3"},
 		}, manager.Env)
 		assert.Equal(t, corev1.ResourceRequirements{
@@ -254,7 +254,7 @@ func TestHelmTemplate_DaemonSet(t *testing.T) {
 		dep := getDaemonSet(t)
 		require.Len(t, dep.Spec.Template.Spec.Containers, 3)
 		manager := dep.Spec.Template.Spec.Containers[0]
-		assert.Equal(t, "outscale/osc-bsu-csi-driver:v1.7.0", manager.Image)
+		assert.Equal(t, "outscale/osc-bsu-csi-driver:v1.8.0", manager.Image)
 		assert.Equal(t, []string{
 			"node",
 			"--endpoint=$(CSI_ENDPOINT)",
@@ -264,7 +264,7 @@ func TestHelmTemplate_DaemonSet(t *testing.T) {
 		assert.Equal(t, []corev1.EnvVar{
 			{Name: "CSI_ENDPOINT", Value: "unix:/csi/csi.sock"},
 			{Name: "BACKOFF_DURATION", Value: "750ms"},
-			{Name: "BACKOFF_FACTOR", Value: "1.4"},
+			{Name: "BACKOFF_FACTOR", Value: "1.6"},
 			{Name: "BACKOFF_STEPS", Value: "3"},
 		}, manager.Env)
 		assert.Equal(t, corev1.ResourceRequirements{
@@ -277,7 +277,7 @@ func TestHelmTemplate_DaemonSet(t *testing.T) {
 		dep := getDaemonSet(t, "maxBsuVolumes=39")
 		require.Len(t, dep.Spec.Template.Spec.Containers, 3)
 		manager := dep.Spec.Template.Spec.Containers[0]
-		assert.Equal(t, "outscale/osc-bsu-csi-driver:v1.7.0", manager.Image)
+		assert.Equal(t, "outscale/osc-bsu-csi-driver:v1.8.0", manager.Image)
 		assert.Equal(t, []string{
 			"node",
 			"--endpoint=$(CSI_ENDPOINT)",
@@ -287,7 +287,7 @@ func TestHelmTemplate_DaemonSet(t *testing.T) {
 		assert.Equal(t, []corev1.EnvVar{
 			{Name: "CSI_ENDPOINT", Value: "unix:/csi/csi.sock"},
 			{Name: "BACKOFF_DURATION", Value: "750ms"},
-			{Name: "BACKOFF_FACTOR", Value: "1.4"},
+			{Name: "BACKOFF_FACTOR", Value: "1.6"},
 			{Name: "BACKOFF_STEPS", Value: "3"},
 			{Name: "MAX_BSU_VOLUMES", Value: "39"},
 		}, manager.Env)

--- a/osc-bsu-csi-driver/templates/controller.yaml
+++ b/osc-bsu-csi-driver/templates/controller.yaml
@@ -291,6 +291,13 @@ spec:
             - --retry-interval-max=5m
             {{- end }}
             - --csi-address=$(ADDRESS)
+            - --v={{ .Values.verbosity }}
+            - --timeout={{ .Values.timeout }}
+            {{- if not (regexMatch "(-kube-api-qps)|(-kube-api-burst)|(-worker-threads)" (join " " .Values.sidecars.snapshotterImage.additionalArgs)) }}
+            - --kube-api-qps=20
+            - --kube-api-burst=100
+            - --worker-threads=100
+            {{- end }}
             # Dynamically adding additionalArgs from values.yaml
             {{- range .Values.sidecars.snapshotterImage.additionalArgs }}
             - {{ . }}

--- a/osc-bsu-csi-driver/values.yaml
+++ b/osc-bsu-csi-driver/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- Container image to use
   repository: outscale/osc-bsu-csi-driver
   # -- Container image tag to deploy
-  tag: v1.7.0
+  tag: v1.8.0
   # -- Container pull policy
   pullPolicy: IfNotPresent
 
@@ -18,7 +18,7 @@ image:
 verbosity: 3
 
 # -- Timeout for sidecars
-timeout: 60s
+timeout: 120s
 
 backoff:
   # integer in second defining initial duration
@@ -26,7 +26,7 @@ backoff:
   duration: "750ms"
   # float define the factor multiplied by Duration each iteration
   # -- Factor multiplied by Duration for each iteration
-  factor: "1.4"
+  factor: "1.6"
   # integer defining the remaining number of iterations in which the duration parameter may change
   # -- Remaining number of iterations in which the duration parameter may change
   steps: "3"


### PR DESCRIPTION
## Description

The snapshotter sidecar did not have any tuning applied.

The timeout is raised from 60s to 120s to reflect that volumes/snapshot are often not ready within 1 min.
The backoff factor is also raised.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [x] Other (specify): tuning

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
