### PR TITLE
✨ feat: check credentials at boot

### DIFF
--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -97,7 +97,6 @@ func TestGetOptions(t *testing.T) {
 	t.Run("all mode given - expect all mode", func(t *testing.T) {
 		options := testFunc(t, []string{"all"}, true, true, true)
 		assert.Equal(t, driver.AllMode, options.DriverMode)
-
 	})
 	t.Run("controller mode given - expect controller mode", func(t *testing.T) {
 		options := testFunc(t, []string{"controller"}, true, true, false)

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -235,7 +235,6 @@ func TestCreateDisk(t *testing.T) {
 		assert.Equal(t, volumeID, vol.VolumeID)
 		mockCtrl.Finish()
 	})
-
 }
 
 func TestDeleteDisk(t *testing.T) {
@@ -1181,4 +1180,15 @@ func TestResizeDisk(t *testing.T) {
 			mockCtrl.Finish()
 		})
 	}
+}
+
+func TestCheckCredentials(t *testing.T) {
+	t.Run("Invalid credentials are rejected with an error", func(t *testing.T) {
+		t.Setenv("OSC_ACCESS_KEY", "foo")
+		t.Setenv("OSC_SECRET_KEY", "bar")
+		c, err := NewCloud("eu-west-2")
+		require.NoError(t, err)
+		err = c.CheckCredentials(t.Context())
+		require.ErrorIs(t, err, ErrInvalidCredentials)
+	})
 }

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -19,6 +19,7 @@ package driver
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"slices"
 	"strconv"
@@ -92,11 +93,15 @@ func newControllerService(driverOptions *DriverOptions) controllerService {
 	}
 }
 
-func (c *controllerService) Start(ctx context.Context) {
+func (c *controllerService) Start(ctx context.Context) error {
 	if c.cloud == nil {
-		return
+		return nil
+	}
+	if err := c.cloud.CheckCredentials(ctx); err != nil {
+		return fmt.Errorf("init cloud: %w", err)
 	}
 	c.cloud.Start(ctx)
+	return nil
 }
 
 func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -157,7 +157,9 @@ func (d *Driver) Run() error {
 		csi.RegisterControllerServer(d.srv, d)
 		ctx, cancel := context.WithCancel(context.Background())
 		d.cancel = cancel
-		d.controllerService.Start(ctx) //nolint
+		if err := d.controllerService.Start(ctx); err != nil { //nolint:staticcheck
+			return err
+		}
 	}
 	if d.options.mode.HasNode() {
 		csi.RegisterNodeServer(d.srv, d)

--- a/pkg/driver/mocks/mock_cloud.go
+++ b/pkg/driver/mocks/mock_cloud.go
@@ -86,6 +86,20 @@ func (mr *MockCloudMockRecorder) CheckCreatedSnapshot(ctx, name any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckCreatedSnapshot", reflect.TypeOf((*MockCloud)(nil).CheckCreatedSnapshot), ctx, name)
 }
 
+// CheckCredentials mocks base method.
+func (m *MockCloud) CheckCredentials(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckCredentials", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CheckCredentials indicates an expected call of CheckCredentials.
+func (mr *MockCloudMockRecorder) CheckCredentials(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckCredentials", reflect.TypeOf((*MockCloud)(nil).CheckCredentials), ctx)
+}
+
 // CreateDisk mocks base method.
 func (m *MockCloud) CreateDisk(ctx context.Context, volumeName string, diskOptions *cloud.DiskOptions) (cloud.Disk, error) {
 	m.ctrl.T.Helper()

--- a/pkg/driver/sanity_test.go
+++ b/pkg/driver/sanity_test.go
@@ -134,6 +134,8 @@ func newFakeCloudProvider() *fakeCloudProvider {
 
 func (c *fakeCloudProvider) Start(ctx context.Context) {}
 
+func (c *fakeCloudProvider) CheckCredentials(ctx context.Context) error { return nil }
+
 func (c *fakeCloudProvider) CreateDisk(ctx context.Context, volumeName string, diskOptions *cloud.DiskOptions) (cloud.Disk, error) {
 	if len(diskOptions.SnapshotID) > 0 {
 		if _, ok := c.snapshots[diskOptions.SnapshotID]; !ok {

--- a/tests/e2e/dynamic_provisioning.go
+++ b/tests/e2e/dynamic_provisioning.go
@@ -712,8 +712,6 @@ var _ = Describe("[bsu-csi-e2e] [single-az] Snapshot", func() {
 			Skip(fmt.Sprintf("env %q not set", OSC_REGION))
 		}
 
-		ctx := context.Background()
-
 		By("Create the Snapshot")
 		tvsc, cleanup := testsuites.CreateVolumeSnapshotClass(snapshotrcs, ns, bsuDriver)
 		defer cleanup()


### PR DESCRIPTION
## Description

When credentials were invalid, the CSI driver started but no error was reported before the first volume/snapshot operation.

The CSI driver now checks the credentials and aborts if credentials are invalid.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
