### PR TITLE
🚀 Helm: bump sidecars, configure automaxprocs

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -10,7 +10,7 @@ on:
       - "Dockerfile"
       - "Makefile"
       - "go.*"
-      - "osc-bsu-csi-driver/**.yaml"
+      - "helm/osc-bsu-csi-driver/**.yaml"
       - ".github/workflows/e2e_test.yml"
   workflow_dispatch:
 

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -73,8 +73,9 @@ Kubernetes: `>=1.20`
 | sidecars.attacher.image | string | `"registry.k8s.io/sig-storage/csi-attacher"` |  |
 | sidecars.attacher.metricsPort | string | `"8090"` | Port of the metrics endpoint |
 | sidecars.attacher.resources | object | `{}` | Sidecar resources. If not set, the top-level resources will be used. |
-| sidecars.attacher.tag | string | `"v4.9.0"` |  |
+| sidecars.attacher.tag | string | `"v4.10.0"` |  |
 | sidecars.attacher.workerThreads | int | `100` |  |
+| sidecars.automaxprocs | bool | `true` | Automatically configure GOMAXPROCS based on container allocated resources. |
 | sidecars.kubeAPI.QPS | int | `20` | Maximum allowed number of queries per second to the Kubernetes API |
 | sidecars.kubeAPI.burst | int | `100` | Allowed burst over QPS |
 | sidecars.leaderElection | object | `{"leaseDuration":null,"renewDeadline":null,"retryPeriod":null}` | leaderElection config for all sidecars |
@@ -84,7 +85,7 @@ Kubernetes: `>=1.20`
 | sidecars.livenessProbe.tag | string | `"v2.16.0"` |  |
 | sidecars.metrics | bool | `false` | activates the metrics HTTP endpoint on sidecars. See each sidecar for port definition. |
 | sidecars.nodeDriverRegistrar.image | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar"` |  |
-| sidecars.nodeDriverRegistrar.tag | string | `"v2.14.0"` |  |
+| sidecars.nodeDriverRegistrar.tag | string | `"v2.15.0"` |  |
 | sidecars.provisioner.additionalArgs | list | `[]` |  |
 | sidecars.provisioner.image | string | `"registry.k8s.io/sig-storage/csi-provisioner"` |  |
 | sidecars.provisioner.metricsPort | string | `"8089"` | Port of the metrics endpoint |

--- a/helm/osc-bsu-csi-driver/templates/controller.yaml
+++ b/helm/osc-bsu-csi-driver/templates/controller.yaml
@@ -126,13 +126,13 @@ spec:
             - --worker-threads={{ .Values.sidecars.provisioner.workerThreads }}
             - --timeout={{ .Values.sidecars.timeout }}
             - --default-fstype={{ .Values.driver.defaultFsType }}
-            - --leader-election=true
             {{- if .Values.driver.enableSnapshotCrossNamespace }}
             - --feature-gates=CrossNamespaceVolumeDataSource=true
             {{- end}}
             {{- if .Values.driver.enableVolumeAttributesClass }}
             - --feature-gates=VolumeAttributesClass=true
             {{- end}}
+            - --leader-election=true
             {{- if .Values.sidecars.leaderElection.leaseDuration }}
             - --leader-election-lease-duration={{ .Values.sidecars.leaderElection.leaseDuration }}
             {{- end }}
@@ -182,6 +182,9 @@ spec:
             - --kube-api-burst={{ .Values.sidecars.kubeAPI.burst }}
             - --worker-threads={{ .Values.sidecars.attacher.workerThreads }}
             - --timeout={{ .Values.sidecars.timeout }}
+            {{- if .Values.sidecars.automaxprocs }}
+            - --automaxprocs
+            {{- end}}
             - --leader-election=true
             {{- if .Values.sidecars.leaderElection.leaseDuration }}
             - --leader-election-lease-duration={{ .Values.sidecars.leaderElection.leaseDuration }}
@@ -233,6 +236,9 @@ spec:
             - --kube-api-burst={{ .Values.sidecars.kubeAPI.burst }}
             - --worker-threads={{ .Values.sidecars.snapshotter.workerThreads }}
             - --timeout={{ .Values.sidecars.timeout }}
+            {{- if .Values.sidecars.automaxprocs }}
+            - --automaxprocs
+            {{- end}}
             - --leader-election=true
             {{- if .Values.sidecars.leaderElection.leaseDuration }}
             - --leader-election-lease-duration={{ .Values.sidecars.leaderElection.leaseDuration }}
@@ -284,6 +290,9 @@ spec:
             - --kube-api-qps={{ .Values.sidecars.kubeAPI.QPS }}
             - --kube-api-burst={{ .Values.sidecars.kubeAPI.burst }}
             - --workers={{ .Values.sidecars.resizer.workerThreads }}
+            {{- if .Values.sidecars.automaxprocs }}
+            - --automaxprocs
+            {{- end}}
             - --leader-election=true
             {{- if .Values.driver.enableVolumeAttributesClass }}
             - --feature-gates=VolumeAttributesClass=true

--- a/helm/osc-bsu-csi-driver/values.yaml
+++ b/helm/osc-bsu-csi-driver/values.yaml
@@ -142,6 +142,8 @@ sidecars:
   timeout: 5m
   # -- Default sidecar resources, unless set at the sidecar level.
   resources: {}
+  # -- Automatically configure GOMAXPROCS based on container allocated resources.
+  automaxprocs: true
   # -- securityContext config for all sidecars.
   securityContext:
     seccompProfile:
@@ -172,7 +174,7 @@ sidecars:
     workerThreads: 100
   attacher:
     image: registry.k8s.io/sig-storage/csi-attacher
-    tag: "v4.9.0"
+    tag: "v4.10.0"
     # -- Port of the metrics endpoint
     metricsPort: "8090"
     additionalArgs: []
@@ -206,4 +208,4 @@ sidecars:
     workerThreads: 100
   nodeDriverRegistrar:
     image: registry.k8s.io/sig-storage/csi-node-driver-registrar
-    tag: "v2.14.0"
+    tag: "v2.15.0"


### PR DESCRIPTION
## Description

Bump minor sidecar releases, add automaxprocs to sidecars.

Note: csi-provisioner v5 does not support automaxprocs, and v6 is currently skipped because of its kube v1.34 requirement.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [x] Other (specify): helm

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
