### PR TITLE
✨ feat(helm): add snapshot exporter sidecar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ helm_deploy:
 			osc-bsu-csi-driver ./helm/osc-bsu-csi-driver \
 			--namespace kube-system \
 			--set driver.enableVolumeSnapshot=true \
+			--set driver.enableVolumeSnapshotExports=true \
 			--set driver.enableVolumeAttributesClass=true \
 			--set cloud.region=${OSC_REGION} \
 			--set driver.image=$(TARGET_IMAGE) \

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -52,6 +52,7 @@ Kubernetes: `>=1.20`
 | driver.enableSnapshotCrossNamespace | bool | `false` | Enable cross namespace snapshots |
 | driver.enableVolumeAttributesClass | bool | `false` | Enable volume updates using VolumeAttributesClass |
 | driver.enableVolumeSnapshot | bool | `false` | Enable volume snapshots |
+| driver.enableVolumeSnapshotExports | bool | `false` | Enable volume snapshots exports |
 | driver.extraSnapshotTags | object | `{}` | Add extra tags on snapshots |
 | driver.extraVolumeTags | object | `{}` | Add extra tags on volumes |
 | driver.fsGroupPolicy | string | `"File"` | Filesystem group policy (see [Docs](https://kubernetes-csi.github.io/docs/support-fsgroup.html#supported-modes)) |
@@ -81,6 +82,11 @@ Kubernetes: `>=1.20`
 | sidecars.attacher.tag | string | `"v4.10.0"` |  |
 | sidecars.attacher.workerThreads | int | `100` |  |
 | sidecars.automaxprocs | bool | `true` | Automatically configure GOMAXPROCS based on container allocated resources. |
+| sidecars.exporter.additionalArgs | list | `[]` |  |
+| sidecars.exporter.image | string | `"outscale/csi-snapshot-exporter"` |  |
+| sidecars.exporter.metricsPort | string | `"8093"` | Port of the metrics endpoint |
+| sidecars.exporter.resources | object | `{}` | Sidecar resources. If not set, the top-level resources will be used. |
+| sidecars.exporter.tag | string | `"v0.1.0"` |  |
 | sidecars.kubeAPI.QPS | int | `20` | Maximum allowed number of queries per second to the Kubernetes API |
 | sidecars.kubeAPI.burst | int | `100` | Allowed burst over QPS |
 | sidecars.leaderElection | object | `{"leaseDuration":null,"renewDeadline":null,"retryPeriod":null}` | leaderElection config for all sidecars |

--- a/helm/osc-bsu-csi-driver/templates/controller.yaml
+++ b/helm/osc-bsu-csi-driver/templates/controller.yaml
@@ -281,6 +281,64 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if .Values.driver.enableVolumeSnapshotExports }}
+        - name: osc-snapshot-exporter
+          image: {{ .Values.sidecars.exporter.image }}:{{ .Values.sidecars.exporter.tag }}
+          imagePullPolicy: {{ .Values.driver.imagePullPolicy }}
+          args:
+            - --v={{ .Values.logs.verbosity }}
+            - --leader-elect=true
+            {{- range .Values.sidecars.exporter.additionalArgs }}
+            - {{ . }}
+            {{- end }}
+          {{- if .Values.sidecars.exporter.metrics }}
+            - --metrics-bind-address=:{{ .Values.sidecars.exporter.metricsPort }}
+          ports:
+            - name: httpendpoint
+              containerPort: {{ .Values.sidecars.exporter.metricsPort }}
+              protocol: TCP
+          {{- end }}
+          env:
+            - name: OSC_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cloud.credentials.secretName }}
+                  key: access_key
+                  optional: true
+            - name: OSC_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cloud.credentials.secretName }}
+                  key: secret_key
+                  optional: true
+            {{- if .Values.cloud.customEndpoint }}
+            - name: OSC_ENDPOINT_API
+              value: {{ .Values.cloud.customEndpoint }}
+            {{- end }}
+            {{- if .Values.cloud.region }}
+            - name: OSC_REGION
+              value: {{ .Values.cloud.region }}
+            {{- end }}
+            {{- if .Values.cloud.httpsProxy }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.cloud.httpsProxy }}
+            - name: NO_PROXY
+              value: {{ .Values.cloud.noProxy }}
+            {{- end }}
+          {{- if .Values.sidecars.exporter.resources }}
+            {{- with .Values.sidecars.exporter.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+            {{- end }}
+          {{- else }}
+            {{- with .Values.sidecars.resources }}
+          resources: {{ toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.sidecars.securityContext }}
+          securityContext:  
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
         {{- end }}
         - name: csi-resizer
           image: {{ .Values.sidecars.resizer.image }}:{{ .Values.sidecars.resizer.tag }}

--- a/helm/osc-bsu-csi-driver/values.yaml
+++ b/helm/osc-bsu-csi-driver/values.yaml
@@ -33,6 +33,8 @@ driver:
   defaultFsType: "ext4"
   # -- Enable volume snapshots
   enableVolumeSnapshot: false
+  # -- Enable volume snapshots exports
+  enableVolumeSnapshotExports: false
   # -- Enable cross namespace snapshots
   enableSnapshotCrossNamespace: false
   # -- Enable volume updates using VolumeAttributesClass
@@ -223,3 +225,11 @@ sidecars:
   nodeDriverRegistrar:
     image: registry.k8s.io/sig-storage/csi-node-driver-registrar
     tag: "v2.15.0"
+  exporter:
+    image: outscale/csi-snapshot-exporter
+    tag: "v0.1.0"
+    # -- Port of the metrics endpoint
+    metricsPort: "8093"
+    additionalArgs: []
+    # -- Sidecar resources. If not set, the top-level resources will be used.
+    resources: {}


### PR DESCRIPTION
## Description

The Helm chart adds a [snapshot exporter sidecar](https://github.com/outscale/csi-snapshot-exporter) to the Helm chart.

The exporter is started if `driver.enableVolumeSnapshot` and `driver.enableVolumeSnapshotExports` are set.

Fixes: #1000 

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
