### PR TITLE
✨ feat(volumes): allow setting total iops

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -113,7 +113,7 @@ The following CSI capabilities are supported by the driver:
 **Notes**
 
 * **EXPAND_VOLUME**: offline (cold/detached) and online (hot/attached) volumes can be resized.
-* **MODIFY_VOLUME**: `volumeType` and `iopsPerGB` can be updated via VolumeAttributeClasses on both offline and online volumes.
+* **MODIFY_VOLUME**: `volumeType`, `iops` and `iopsPerGB` can be updated via VolumeAttributeClasses on both offline and online volumes.
 
 </details>
 
@@ -163,7 +163,8 @@ These parameters are passed via the StorageClass to `CreateVolumeRequest.paramet
 | ------------------------------------------------ | ------------------------ | ------- | ------------------------------------------------------------------ |
 | `csi.storage.k8s.io/fstype`                      | `xfs`, `ext2/3/4`        | `ext4`  | Filesystem to format the volume with.                              |
 | `type`                                           | `io1`, `gp2`, `standard` | `gp2`   | BSU volume type.                                                   |
-| `iopsPerGB`                                      | integer                  | —       | Required when `type=io1`; IOPS per GiB.                            |
+| `iops`                                      | integer                  | —       | Either `iops` or `iopsPerGB` is required when `type=io1`; total IOPS.                            |
+| `iopsPerGB`                                      | integer                  | —       | Either `iops` or `iopsPerGB` is required when `type=io1`; IOPS per GiB.                            |
 | `encrypted`                                      | `true`, `false`          | `false` | Enable LUKS encryption.                                            |
 | `csi.storage.k8s.io/node-stage-secret-name`      | string                   | —       | Name of the node-stage secret (see CSI docs).                      |
 | `csi.storage.k8s.io/node-stage-secret-namespace` | string                   | —       | Namespace of the node-stage secret (see CSI docs).                 |

--- a/docs/storageclass.md
+++ b/docs/storageclass.md
@@ -15,14 +15,14 @@ metadata:
 provisioner: bsu.csi.outscale.com
 parameters:
   type: io1
-  iopsPerGB: "10"
+  iops: "1000"
   csi.storage.k8s.io/fstype: ext4
 ```
 
 * `type`: `standard`, `gp2`, `io1`. See
   [Outscale docs](https://docs.outscale.com/en/userguide/About-Volumes.html#AboutVolumes-VolumeTypesVolumeTypesandIOPS)
   for details. Default: `gp2`.
-* `iopsPerGB`: only for `io1` volumes. I/O operations per second per GiB. 
+* `iops`: only for `io1` volumes. Total I/O operations per second. 
   [Outscale docs](https://docs.outscale.com/en/userguide/About-Volumes.html#AboutVolumes-VolumeTypesVolumeTypesandIOPS).
-  A string is expected here, i.e. `"10"`, not `10`.
+  A string is expected here, i.e. `"1000"`, not `1000`.
 * `fsType`: fsType that is supported by kubernetes. Default: `"ext4"`.

--- a/examples/kubernetes/encryption/specs/storageclass.yaml
+++ b/examples/kubernetes/encryption/specs/storageclass.yaml
@@ -9,7 +9,7 @@ parameters:
   encrypted: 'true'
   luks-cipher: aes-xts-plain64
   type: io1
-  iopsPerGB: '50'
+  iops: '500'
   csi.storage.k8s.io/node-stage-secret-name: luks-key
   csi.storage.k8s.io/node-stage-secret-namespace: encryption
   csi.storage.k8s.io/node-expand-secret-name: luks-key

--- a/examples/kubernetes/storageclass/specs/example.yaml
+++ b/examples/kubernetes/storageclass/specs/example.yaml
@@ -7,7 +7,7 @@ volumeBindingMode: WaitForFirstConsumer
 parameters:
   csi.storage.k8s.io/fstype: xfs
   type: io1
-  iopsPerGB: "50"
+  iops: "1000"
 allowedTopologies:
 - matchLabelExpressions:
   - key: topology.bsu.csi.outscale.com/zone

--- a/examples/kubernetes/volume-attribute-class/specs/volumeattributeclass.yaml
+++ b/examples/kubernetes/volume-attribute-class/specs/volumeattributeclass.yaml
@@ -4,7 +4,7 @@ metadata:
   name: bsu-vac
 provisioner: bsu.csi.outscale.com
 parameters:
-  iopspergb: "500"
+  iops: "1000"
   type: "io1"
 ---
 kind: VolumeAttributesClass
@@ -13,5 +13,5 @@ metadata:
   name: bsu-vac-after
 provisioner: bsu.csi.outscale.com
 parameters:
-  iopspergb: "1000"
+  iops: "2000"
   type: "io1"

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -98,6 +98,7 @@ type Volume struct {
 	SnapshotID       *string
 	VolumeType       osc.VolumeType
 	IOPSPerGB        int
+	IOPS             int
 }
 
 // VolumeOptions represents parameters to create an BSU volume
@@ -106,6 +107,7 @@ type VolumeOptions struct {
 	Tags          map[string]string
 	VolumeType    osc.VolumeType
 	IOPSPerGB     int
+	IOPS          int
 	SubRegion     string
 	Encrypted     bool
 	// KmsKeyID represents a fully qualified resource name to the key to use for encryption.
@@ -150,7 +152,7 @@ type Cloud interface {
 	AttachVolume(ctx context.Context, volumeID string, nodeID string) (devicePath string, err error)
 	DetachVolume(ctx context.Context, volumeID string, nodeID string) (err error)
 	ResizeVolume(ctx context.Context, volumeID string, reqSize int64) (newSize int64, err error)
-	UpdateVolume(ctx context.Context, volumeID string, volumeType osc.VolumeType, iopsPerGB int) (err error)
+	UpdateVolume(ctx context.Context, volumeID string, volumeType osc.VolumeType, iops, iopsPerGB int) (err error)
 	WaitForAttachmentState(ctx context.Context, volumeID string, state osc.LinkedVolumeState) error
 	CheckCreatedVolume(ctx context.Context, name string) (vol *Volume, err error)
 	GetVolumeByID(ctx context.Context, volumeID string) (vol *Volume, err error)
@@ -212,7 +214,7 @@ func (c *cloud) Start(ctx context.Context) {
 	go c.volumeWatcher.Run(ctx)
 }
 
-func iops(iopsPerGB, capacityGiB int) int {
+func computeIOPS(iopsPerGB, capacityGiB int) int {
 	iopsPerGB = min(iopsPerGB, MaxIopsPerGb)
 	return min(
 		max(capacityGiB*iopsPerGB, MinTotalIOPS),
@@ -243,8 +245,12 @@ func (c *cloud) CreateVolume(ctx context.Context, name string, opts *VolumeOptio
 		createType = opts.VolumeType
 	case osc.VolumeTypeIo1:
 		createType = osc.VolumeTypeIo1
-		iops := iops(opts.IOPSPerGB, capacityGiB)
-		request.Iops = &iops
+		if opts.IOPS > 0 {
+			request.Iops = &opts.IOPS
+		} else {
+			iops := computeIOPS(opts.IOPSPerGB, capacityGiB)
+			request.Iops = &iops
+		}
 	case "":
 		createType = DefaultVolumeType
 	default:
@@ -289,7 +295,7 @@ func (c *cloud) CreateVolume(ctx context.Context, name string, opts *VolumeOptio
 
 	return &Volume{
 		CapacityGiB: vol.Size, VolumeID: vol.VolumeId, AvailabilityZone: zone, SnapshotID: vol.SnapshotId,
-		VolumeType: vol.VolumeType, IOPSPerGB: vol.Iops / vol.Size,
+		VolumeType: vol.VolumeType, IOPSPerGB: vol.Iops / vol.Size, IOPS: vol.Iops,
 	}, nil
 }
 
@@ -490,6 +496,7 @@ func (c *cloud) CheckCreatedVolume(ctx context.Context, name string) (*Volume, e
 		SnapshotID:       vol.SnapshotId,
 		VolumeType:       vol.VolumeType,
 		IOPSPerGB:        vol.Iops / vol.Size,
+		IOPS:             vol.Iops,
 	}, nil
 }
 
@@ -509,6 +516,7 @@ func (c *cloud) GetVolumeByID(ctx context.Context, volumeID string) (*Volume, er
 		SnapshotID:       vol.SnapshotId,
 		VolumeType:       vol.VolumeType,
 		IOPSPerGB:        vol.Iops / vol.Size,
+		IOPS:             vol.Iops,
 	}, nil
 }
 
@@ -796,7 +804,7 @@ func (c *cloud) waitForResize(ctx context.Context, volumeID string, newSizeGiB i
 }
 
 // UpdateVolume updates the type and iops of a volume.
-func (c *cloud) UpdateVolume(ctx context.Context, volumeID string, volumeType osc.VolumeType, iopsPerGB int) (err error) {
+func (c *cloud) UpdateVolume(ctx context.Context, volumeID string, volumeType osc.VolumeType, iops, iopsPerGB int) (err error) {
 	logger := klog.FromContext(ctx)
 	request := osc.ReadVolumesRequest{
 		Filters: &osc.FiltersVolume{
@@ -808,7 +816,9 @@ func (c *cloud) UpdateVolume(ctx context.Context, volumeID string, volumeType os
 		return err
 	}
 
-	iops := iops(iopsPerGB, vol.Size)
+	if iops == 0 {
+		iops = computeIOPS(iopsPerGB, vol.Size)
+	}
 	req := osc.UpdateVolumeRequest{
 		VolumeId: volumeID,
 	}

--- a/pkg/driver/constants.go
+++ b/pkg/driver/constants.go
@@ -28,6 +28,9 @@ const (
 	// VolumeTypeKey represents key for volume type
 	VolumeTypeKey = "type"
 
+	// Iops represents key for IOPS
+	IopsKey = "iops"
+
 	// IopsPerGBKey represents key for IOPS per GB
 	IopsPerGBKey = "iopspergb"
 

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -103,7 +103,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 
 	var (
 		volumeType         osc.VolumeType
-		iopsPerGB          int64
+		iops, iopsPerGB    int64
 		isEncrypted        bool
 		kmsKeyID           string
 		luksCipher         string
@@ -118,6 +118,11 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 			klog.FromContext(ctx).V(2).Info(`"fstype" is deprecated, please use "csi.storage.k8s.io/fstype" instead`)
 		case VolumeTypeKey:
 			volumeType = osc.VolumeType(value)
+		case IopsKey:
+			iops, err = strconv.ParseInt(value, 10, 32)
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "Could not parse invalid iops: %v", err)
+			}
 		case IopsPerGBKey:
 			iopsPerGB, err = strconv.ParseInt(value, 10, 32)
 			if err != nil {
@@ -190,6 +195,7 @@ func (d *controllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		CapacityBytes: volSizeBytes,
 		Tags:          d.driverOptions.extraVolumeTags,
 		VolumeType:    volumeType,
+		IOPS:          int(iops),
 		IOPSPerGB:     int(iopsPerGB),
 		SubRegion:     zone,
 		Encrypted:     isEncrypted,
@@ -355,14 +361,20 @@ func (d *controllerService) ControllerModifyVolume(ctx context.Context, req *csi
 	}
 
 	var (
-		volumeType osc.VolumeType
-		iopsPerGB  int64
+		volumeType      osc.VolumeType
+		iops, iopsPerGB int64
 	)
 
 	for key, value := range req.GetMutableParameters() {
 		switch strings.ToLower(key) {
 		case VolumeTypeKey:
 			volumeType = osc.VolumeType(value)
+		case IopsKey:
+			var err error
+			iops, err = strconv.ParseInt(value, 10, 32)
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "Invalid iops value: %v", err)
+			}
 		case IopsPerGBKey:
 			var err error
 			iopsPerGB, err = strconv.ParseInt(value, 10, 32)
@@ -374,7 +386,7 @@ func (d *controllerService) ControllerModifyVolume(ctx context.Context, req *csi
 		}
 	}
 
-	err := d.cloud.UpdateVolume(ctx, volumeID, volumeType, int(iopsPerGB))
+	err := d.cloud.UpdateVolume(ctx, volumeID, volumeType, int(iops), int(iopsPerGB))
 	if err != nil {
 		return nil, status.Errorf(cloud.GRPCCode(err), "Could not modify volume %q: %v", volumeID, err)
 	}

--- a/pkg/driver/controller_test.go
+++ b/pkg/driver/controller_test.go
@@ -377,18 +377,16 @@ func TestCreateVolume(t *testing.T) {
 			t.Fatalf("Expected volume capacity bytes: %v, got: %v", expVol.GetCapacityBytes(), vol.GetCapacityBytes())
 		}
 	})
-	t.Run("success with volume type io1", func(t *testing.T) {
+	t.Run("success with volume type io1 and iops", func(t *testing.T) {
 		req := &csi.CreateVolumeRequest{
 			Name:               "vol-test",
 			CapacityRange:      stdCapRange,
 			VolumeCapabilities: stdVolCap,
 			Parameters: map[string]string{
 				VolumeTypeKey: string(osc.VolumeTypeIo1),
-				IopsPerGBKey:  "5",
+				IopsKey:       "50",
 			},
 		}
-
-		ctx := t.Context()
 
 		mockVolume := &cloud.Volume{
 			VolumeID:         req.Name,
@@ -400,15 +398,55 @@ func TestCreateVolume(t *testing.T) {
 		defer mockCtl.Finish()
 
 		mockCloud := mocks.NewMockCloud(mockCtl)
-		mockCloud.EXPECT().CheckCreatedVolume(gomock.Eq(ctx), gomock.Eq(req.Name)).Return(nil, cloud.ErrNotFound)
-		mockCloud.EXPECT().CreateVolume(gomock.Eq(ctx), gomock.Eq(req.Name), gomock.Any()).Return(mockVolume, nil)
+		mockCloud.EXPECT().CheckCreatedVolume(gomock.Any(), gomock.Eq(req.Name)).Return(nil, cloud.ErrNotFound)
+		mockCloud.EXPECT().CreateVolume(gomock.Any(), gomock.Eq(req.Name), gomock.Eq(&cloud.VolumeOptions{
+			CapacityBytes: stdVolSize,
+			VolumeType:    osc.VolumeTypeIo1,
+			IOPS:          50,
+		})).Return(mockVolume, nil)
 
 		oscDriver := controllerService{
 			cloud:         mockCloud,
 			driverOptions: &DriverOptions{},
 		}
 
-		_, err := oscDriver.CreateVolume(ctx, req)
+		_, err := oscDriver.CreateVolume(t.Context(), req)
+		require.NoError(t, err)
+	})
+	t.Run("success with volume type io1 and iopsPerGB", func(t *testing.T) {
+		req := &csi.CreateVolumeRequest{
+			Name:               "vol-test",
+			CapacityRange:      stdCapRange,
+			VolumeCapabilities: stdVolCap,
+			Parameters: map[string]string{
+				VolumeTypeKey: string(osc.VolumeTypeIo1),
+				IopsPerGBKey:  "5",
+			},
+		}
+
+		mockVolume := &cloud.Volume{
+			VolumeID:         req.Name,
+			AvailabilityZone: expZone,
+			CapacityGiB:      util.BytesToGiB(stdVolSize),
+		}
+
+		mockCtl := gomock.NewController(t)
+		defer mockCtl.Finish()
+
+		mockCloud := mocks.NewMockCloud(mockCtl)
+		mockCloud.EXPECT().CheckCreatedVolume(gomock.Any(), gomock.Eq(req.Name)).Return(nil, cloud.ErrNotFound)
+		mockCloud.EXPECT().CreateVolume(gomock.Any(), gomock.Eq(req.Name), gomock.Eq(&cloud.VolumeOptions{
+			CapacityBytes: stdVolSize,
+			VolumeType:    osc.VolumeTypeIo1,
+			IOPSPerGB:     5,
+		})).Return(mockVolume, nil)
+
+		oscDriver := controllerService{
+			cloud:         mockCloud,
+			driverOptions: &DriverOptions{},
+		}
+
+		_, err := oscDriver.CreateVolume(t.Context(), req)
 		require.NoError(t, err)
 	})
 	t.Run("success with volume type sc1", func(t *testing.T) {

--- a/pkg/driver/mocks/mock_cloud.go
+++ b/pkg/driver/mocks/mock_cloud.go
@@ -248,17 +248,17 @@ func (mr *MockCloudMockRecorder) Start(ctx any) *gomock.Call {
 }
 
 // UpdateVolume mocks base method.
-func (m *MockCloud) UpdateVolume(ctx context.Context, volumeID string, volumeType osc.VolumeType, iopsPerGB int) error {
+func (m *MockCloud) UpdateVolume(ctx context.Context, volumeID string, volumeType osc.VolumeType, iops, iopsPerGB int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateVolume", ctx, volumeID, volumeType, iopsPerGB)
+	ret := m.ctrl.Call(m, "UpdateVolume", ctx, volumeID, volumeType, iops, iopsPerGB)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateVolume indicates an expected call of UpdateVolume.
-func (mr *MockCloudMockRecorder) UpdateVolume(ctx, volumeID, volumeType, iopsPerGB any) *gomock.Call {
+func (mr *MockCloudMockRecorder) UpdateVolume(ctx, volumeID, volumeType, iops, iopsPerGB any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVolume", reflect.TypeOf((*MockCloud)(nil).UpdateVolume), ctx, volumeID, volumeType, iopsPerGB)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVolume", reflect.TypeOf((*MockCloud)(nil).UpdateVolume), ctx, volumeID, volumeType, iops, iopsPerGB)
 }
 
 // WaitForAttachmentState mocks base method.

--- a/tests/e2e/driver/bsu_csi_driver.go
+++ b/tests/e2e/driver/bsu_csi_driver.go
@@ -163,7 +163,20 @@ func (d *bsuCSIDriver) GetPassphraseSecret(name string, passphrase string) *v1.S
 	}
 }
 
-func (d *bsuCSIDriver) GetVolumeAttributesClass(namespace, name string, volumeType osc.VolumeType, iopsPerGB string) *storagev1beta1.VolumeAttributesClass {
+func (d *bsuCSIDriver) GetVolumeAttributesClass(namespace, name string, volumeType osc.VolumeType, iops bool, iopsPerGB string) *storagev1beta1.VolumeAttributesClass {
+	if iops {
+		return &storagev1beta1.VolumeAttributesClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			DriverName: d.driverName,
+			Parameters: map[string]string{
+				bsucsidriver.VolumeTypeKey: string(volumeType),
+				bsucsidriver.IopsKey:       iopsPerGB,
+			},
+		}
+	}
 	return &storagev1beta1.VolumeAttributesClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/tests/e2e/driver/driver.go
+++ b/tests/e2e/driver/driver.go
@@ -43,7 +43,7 @@ type DynamicPVTestDriver interface {
 	GetPassphraseSecret(name string, passphrase string) *v1.Secret
 
 	// GetVolumeAttributesClass returns a StorageClass dynamic provision Persistent Volume
-	GetVolumeAttributesClass(namespace, name string, volumeType osc.VolumeType, iopsPerGB string) *storagev1beta1.VolumeAttributesClass
+	GetVolumeAttributesClass(namespace, name string, volumeType osc.VolumeType, iops bool, iopsPerGB string) *storagev1beta1.VolumeAttributesClass
 }
 
 // PreProvisionedVolumeTestDriver represents an interface for a CSI driver that supports pre-provisioned volume

--- a/tests/e2e/dynamic_provisioning.go
+++ b/tests/e2e/dynamic_provisioning.go
@@ -910,7 +910,33 @@ var _ = Describe("[bsu-csi-e2e] [single-az] Updating iops/volumeType using Volum
 		cancel()
 	})
 
-	It("should create a volume and update iops & type (offline)", func() {
+	It("should create a volume and update iops & type (iops/offline)", func() {
+		pod := testsuites.PodDetails{
+			Cmd: "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
+			Volumes: []testsuites.VolumeDetails{
+				{
+					VolumeType: osc.VolumeTypeGp2,
+					FSType:     bsucsidriver.FSTypeExt4,
+					ClaimSize:  driver.MinimumSizeForVolumeType(osc.VolumeTypeIo1),
+					VolumeMount: testsuites.VolumeMountDetails{
+						NameGenerate:      "test-volume-",
+						MountPathGenerate: "/mnt/test-",
+					},
+					VolumeAttributeClass: "test-volumeattributeclass",
+				},
+			},
+		}
+
+		test := testsuites.DynamicallyProvisionedModifyVolumeTest{
+			CSIDriver: bsuDriver,
+			Pod:       pod,
+			Cloud:     cloud,
+			IOPS:      true,
+		}
+		test.Run(cs, ns)
+	})
+
+	It("should create a volume and update iops & type (iopsPerGB/offline)", func() {
 		pod := testsuites.PodDetails{
 			Cmd: "echo 'hello world' >> /mnt/test-1/data && grep 'hello world' /mnt/test-1/data && sync",
 			Volumes: []testsuites.VolumeDetails{
@@ -935,7 +961,7 @@ var _ = Describe("[bsu-csi-e2e] [single-az] Updating iops/volumeType using Volum
 		test.Run(cs, ns)
 	})
 
-	It("should create a volume and update iops & type (online)", func() {
+	It("should create a volume and update iops & type (iops/online)", func() {
 		pod := testsuites.PodDetails{
 			Cmd: "while true; do echo $(date -u) >> /mnt/test-1/data; sleep 1; done",
 			Volumes: []testsuites.VolumeDetails{
@@ -957,6 +983,7 @@ var _ = Describe("[bsu-csi-e2e] [single-az] Updating iops/volumeType using Volum
 			Pod:       pod,
 			Cloud:     cloud,
 			Online:    true,
+			IOPS:      true,
 		}
 		test.Run(cs, ns)
 	})

--- a/tests/e2e/testsuites/dynamically_provisioned_modify_volume_tester.go
+++ b/tests/e2e/testsuites/dynamically_provisioned_modify_volume_tester.go
@@ -40,13 +40,17 @@ type DynamicallyProvisionedModifyVolumeTest struct {
 	Pod       PodDetails
 	Cloud     cloud.Cloud
 	Online    bool
+	IOPS      bool
 }
 
 func (t *DynamicallyProvisionedModifyVolumeTest) Run(client clientset.Interface, namespace *v1.Namespace) {
 	volume := t.Pod.Volumes[0]
 	baseType := osc.VolumeTypeGp2
 	baseIops := "100"
-	tvac, _ := volume.SetupVolumeAttributesClass(client, namespace, volume.VolumeAttributeClass, baseType, baseIops, t.CSIDriver)
+	if t.IOPS {
+		baseIops = "400"
+	}
+	tvac, _ := volume.SetupVolumeAttributesClass(client, namespace, volume.VolumeAttributeClass, baseType, t.IOPS, baseIops, t.CSIDriver)
 	defer tvac.Cleanup()
 	tpvc, _ := volume.SetupDynamicPersistentVolumeClaim(client, namespace, t.CSIDriver)
 	defer tpvc.Cleanup()
@@ -72,7 +76,10 @@ func (t *DynamicallyProvisionedModifyVolumeTest) Run(client clientset.Interface,
 	updatedName := volume.VolumeAttributeClass + "-new"
 	updatedType := osc.VolumeTypeIo1
 	updatedIops := "200"
-	ntvac, _ := volume.SetupVolumeAttributesClass(client, namespace, updatedName, updatedType, updatedIops, t.CSIDriver)
+	if t.IOPS {
+		updatedIops = "600"
+	}
+	ntvac, _ := volume.SetupVolumeAttributesClass(client, namespace, updatedName, updatedType, t.IOPS, updatedIops, t.CSIDriver)
 	defer ntvac.Cleanup()
 	pvc.Spec.VolumeAttributesClassName = &updatedName
 	_, err := client.CoreV1().PersistentVolumeClaims(namespace.Name).Update(context.TODO(), pvc, metav1.UpdateOptions{})
@@ -111,8 +118,13 @@ func (t *DynamicallyProvisionedModifyVolumeTest) WaitForPvToModify(client client
 			if err != nil {
 				continue
 			}
-			By(fmt.Sprintf("volumeType %q iops %d", dsk.VolumeType, dsk.IOPSPerGB))
-			if dsk.VolumeType != desiredType || strconv.FormatInt(int64(dsk.IOPSPerGB), 10) != desiredIops {
+			By(fmt.Sprintf("volumeType %q (expected %q) iops %d perGB %d (expected %s)", dsk.VolumeType, desiredType, dsk.IOPS, dsk.IOPSPerGB, desiredIops))
+			switch {
+			case dsk.VolumeType != desiredType:
+				continue
+			case t.IOPS && strconv.Itoa(dsk.IOPS) != desiredIops:
+				continue
+			case !t.IOPS && strconv.Itoa(dsk.IOPSPerGB) != desiredIops:
 				continue
 			}
 			return nil

--- a/tests/e2e/testsuites/specs.go
+++ b/tests/e2e/testsuites/specs.go
@@ -178,10 +178,10 @@ func (volume *VolumeDetails) SetupDynamicPersistentVolumeClaim(client clientset.
 	return tpvc, cleanupFuncs
 }
 
-func (volume *VolumeDetails) SetupVolumeAttributesClass(client clientset.Interface, namespace *v1.Namespace, name string, volumeType osc.VolumeType, iopsPerGB string, csiDriver driver.DynamicPVTestDriver) (*TestVolumeAttributesClass, []func()) {
+func (volume *VolumeDetails) SetupVolumeAttributesClass(client clientset.Interface, namespace *v1.Namespace, name string, volumeType osc.VolumeType, iops bool, iopsPerGB string, csiDriver driver.DynamicPVTestDriver) (*TestVolumeAttributesClass, []func()) {
 	cleanupFuncs := make([]func(), 0, 1)
 	By("setting up the VolumeAttributesClass")
-	vac := csiDriver.GetVolumeAttributesClass(namespace.Name, name, volumeType, iopsPerGB)
+	vac := csiDriver.GetVolumeAttributesClass(namespace.Name, name, volumeType, iops, iopsPerGB)
 	tvac := NewTestVolumeAttributesClass(client, vac)
 	_ = tvac.Create()
 	cleanupFuncs = append(cleanupFuncs, tvac.Cleanup)


### PR DESCRIPTION
## Description

This PR allows setting total IOPS using the `iops` parameter in addition to `iopsPerGB`.

```yaml
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: bsu-sc
provisioner: bsu.csi.outscale.com
volumeBindingMode: WaitForFirstConsumer
parameters:
  type: io1
  iops: '500'
```

Fixes: #1153 

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [x] E2E tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
