### PR TITLE
✨ feat(node): dynamic annotation based volume limits

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -38,3 +38,25 @@ helm upgrade --install osc-bsu-csi-driver oci://docker.io/outscalehelm/osc-bsu-c
 ```shell
 kubectl get pod -n kube-system -l "app.kubernetes.io/name=osc-bsu-csi-driver"
 ```
+
+## Setting volume limits
+
+Up to 39 volumes, including PVCs and OS-level mounts, can be attached to a node.
+
+The CSI driver automatically counts how many volumes are mounted by the OS and reports the calculated volume limit to Kubernetes.
+
+If the automatic calculation is not suitable, you can set a manual limit.
+
+### Global limit
+
+The `driver.maxBsuVolumes` Helm value can be used to set a global limit. All nodes will use this value.
+
+### Per node limit (v1.11.0 and later)
+
+The `bsu.csi.outscale.com/maxvolumes` annotation can be set on nodes and its value will be used as the limit for the corresponding node.
+
+If both limits are set, the annotation limit takes precedence.
+
+### Dynamic values (v1.11.0 and later)
+
+If you activate the [`MutableCSINodeAllocatableCount` feature gate](https://kubernetes.io/blog/2025/05/02/kubernetes-1-33-mutable-csi-node-allocatable-count/), Kubernetes periodically refreshes the limit by asking the CSI driver to compute a new automatic limit and check for an updated node annotation.

--- a/helm/osc-bsu-csi-driver/helm_test.go
+++ b/helm/osc-bsu-csi-driver/helm_test.go
@@ -414,6 +414,11 @@ func TestHelmTemplate_DaemonSet(t *testing.T) {
 		}, manager.Args)
 		assert.Equal(t, []corev1.EnvVar{
 			{Name: "CSI_ENDPOINT", Value: "unix:/csi/csi.sock"},
+			{Name: "NODE_NAME", ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			}},
 		}, manager.Env)
 		assert.Equal(t, corev1.ResourceRequirements{
 			Requests: nil,
@@ -435,6 +440,11 @@ func TestHelmTemplate_DaemonSet(t *testing.T) {
 		manager := dep.Spec.Template.Spec.Containers[0]
 		assert.Equal(t, []corev1.EnvVar{
 			{Name: "CSI_ENDPOINT", Value: "unix:/csi/csi.sock"},
+			{Name: "NODE_NAME", ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "spec.nodeName",
+				},
+			}},
 			{Name: "MAX_BSU_VOLUMES", Value: "39"},
 		}, manager.Env)
 		assert.Equal(t, corev1.ResourceRequirements{

--- a/helm/osc-bsu-csi-driver/templates/node.yaml
+++ b/helm/osc-bsu-csi-driver/templates/node.yaml
@@ -64,6 +64,10 @@ spec:
           env:
             - name: CSI_ENDPOINT
               value: unix:/csi/csi.sock
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           {{- if .Values.driver.maxBsuVolumes }}
             - name: MAX_BSU_VOLUMES
               value: "{{ .Values.driver.maxBsuVolumes }}"
@@ -92,7 +96,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.node.securityContext }}
-          securityContext:  
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         - name: node-driver-registrar
@@ -130,7 +134,7 @@ spec:
             {{- end }}
           {{- end }}
           {{- with .Values.sidecars.securityContext }}
-          securityContext:  
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         - name: liveness-probe
@@ -152,7 +156,7 @@ spec:
             {{- end }}
           {{- end }}
           {{- with .Values.sidecars.securityContext }}
-          securityContext:  
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
       volumes:

--- a/pkg/driver/k8s/client.go
+++ b/pkg/driver/k8s/client.go
@@ -1,0 +1,51 @@
+package k8s
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+var (
+	backoff = wait.Backoff{
+		Duration: 1 * time.Second,
+		Factor:   2.0,
+		Steps:    5,
+	}
+
+	GetClient = func() (kubernetes.Interface, error) {
+		cfg, err := rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+		return kubernetes.NewForConfig(cfg)
+	}
+)
+
+func GetNode(ctx context.Context, name string) (*corev1.Node, error) {
+	client, err := GetClient()
+	if err != nil {
+		return nil, err
+	}
+
+	var node *corev1.Node
+	err = wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		var err error
+		node, err = client.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+		switch {
+		case apierrors.IsNotFound(err):
+			return false, err
+		case err != nil:
+			return false, nil //nolint: nilerr
+		default:
+			return true, nil
+		}
+	})
+	return node, err
+}

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -29,10 +29,12 @@ import (
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/outscale/goutils/sdk/metadata"
 	"github.com/outscale/osc-bsu-csi-driver/pkg/driver/internal"
+	"github.com/outscale/osc-bsu-csi-driver/pkg/driver/k8s"
 	"github.com/outscale/osc-bsu-csi-driver/pkg/driver/luks"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/volume"
 	mountutils "k8s.io/mount-utils"
@@ -54,6 +56,10 @@ const (
 	// defaultMaxBSUVolumes is the maximum number of volumes that an OSC instance can have attached, including root volume.
 	// https://docs.outscale.com/en/userguide/About-Volumes.html#_volumes_and_instances
 	defaultMaxBSUVolumes = 40
+
+	NodeLimitAnnotation = DriverName + "/maxvolumes"
+	NodeNameEnv         = "NODE_NAME"
+	MaxVolumesEnv       = "MAX_BSU_VOLUMES"
 )
 
 var ValidFSTypes = []string{FSTypeExt2, FSTypeExt3, FSTypeExt4, FSTypeXfs}
@@ -70,9 +76,10 @@ type nodeService struct {
 	driverOptions *DriverOptions
 	instanceID    string
 	subRegion     string
-	mounter       Mounter
-	maxVolumes    int64
-	inFlight      *internal.InFlight
+	nodeName      string
+
+	mounter  Mounter
+	inFlight *internal.InFlight
 
 	csi.UnimplementedNodeServer
 }
@@ -97,11 +104,8 @@ func newNodeService(ctx context.Context, driverOptions *DriverOptions) (nodeServ
 	if err != nil {
 		return nodeService{}, err
 	}
-	maxVols, err := srv.getVolumesLimit()
-	if err != nil {
-		panic(err)
-	}
-	srv.maxVolumes = maxVols
+	srv.nodeName = os.Getenv(NodeNameEnv)
+
 	return srv, nil
 }
 
@@ -592,9 +596,13 @@ func (s *nodeService) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 	topology := &csi.Topology{
 		Segments: map[string]string{TopologyKey: s.subRegion},
 	}
+	maxVolumes, err := s.getVolumesLimit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("compute limit: %w", err)
+	}
 	return &csi.NodeGetInfoResponse{
 		NodeId:             s.instanceID,
-		MaxVolumesPerNode:  s.maxVolumes,
+		MaxVolumesPerNode:  maxVolumes,
 		AccessibleTopology: topology,
 	}, nil
 }
@@ -767,12 +775,48 @@ func findScsiVolume(findName string) (device string, err error) {
 	return resolved, nil
 }
 
+func getMaxVolumesFromNode(ctx context.Context, n *corev1.Node) (int64, bool) {
+	if n.Annotations == nil {
+		return 0, false
+	}
+	value, ok := n.Annotations[NodeLimitAnnotation]
+	if !ok {
+		return 0, false
+	}
+	limit, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		klog.FromContext(ctx).Error(err, "Ignoring invalid "+NodeLimitAnnotation+" annotation value", "value", value)
+		return 0, false
+	}
+	if limit <= 0 || limit >= defaultMaxBSUVolumes {
+		klog.FromContext(ctx).Info("Ignoring out of bounds "+NodeLimitAnnotation+" annotation value", "value", value)
+		return 0, false
+	}
+	return limit, true
+}
+
 // getVolumesLimit returns the limit of volumes that the node can mount (40 - OS mounted devices, including root device)
-func (s *nodeService) getVolumesLimit() (int64, error) {
+func (s *nodeService) getVolumesLimit(ctx context.Context) (int64, error) {
+	// checking labels
+	node, err := k8s.GetNode(ctx, s.nodeName)
+	switch {
+	case err != nil:
+		klog.FromContext(ctx).Error(err, "Unable to fetch node, not checking annotations", "nodeName", s.nodeName)
+	default:
+		if maxVolumes, ok := getMaxVolumesFromNode(ctx, node); ok {
+			klog.FromContext(ctx).V(3).Info("Setting limit from node annotation", "maxVolumes", maxVolumes)
+			return maxVolumes, nil
+		}
+	}
+
+	// checking env
 	maxVolumes := getEnvMaxVolume()
 	if maxVolumes > 0 {
+		klog.FromContext(ctx).V(3).Info("Setting limit from env", "maxVolumes", maxVolumes)
 		return maxVolumes, nil
 	}
+
+	// checking mounts
 	mounts, err := s.mounter.List()
 	if err != nil {
 		return -1, fmt.Errorf("unable to list mounts: %w", err)
@@ -790,11 +834,13 @@ func (s *nodeService) getVolumesLimit() (int64, error) {
 			devs = append(devs, m.Device)
 		}
 	}
-	return defaultMaxBSUVolumes - int64(len(devs)), nil
+	maxVolumes = defaultMaxBSUVolumes - int64(len(devs))
+	klog.FromContext(ctx).V(3).Info("Computed limit", "maxVolumes", maxVolumes)
+	return maxVolumes, nil
 }
 
 func getEnvMaxVolume() int64 {
-	value := os.Getenv("MAX_BSU_VOLUMES")
+	value := os.Getenv(MaxVolumesEnv)
 	if value == "" {
 		return -1
 	}

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/outscale/osc-bsu-csi-driver/pkg/driver/internal"
+	"github.com/outscale/osc-bsu-csi-driver/pkg/driver/k8s"
 	"github.com/outscale/osc-bsu-csi-driver/pkg/driver/luks"
 	"github.com/outscale/osc-bsu-csi-driver/pkg/driver/mocks"
 	"github.com/stretchr/testify/assert"
@@ -32,9 +33,15 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 	exec "k8s.io/utils/exec"
 	"k8s.io/utils/mount"
 )
+
+const nodeName = "node-foo"
 
 func TestNodeStageVolume(t *testing.T) {
 	var (
@@ -1626,6 +1633,8 @@ func TestNodeGetInfo(t *testing.T) {
 		name          string
 		instanceID    string
 		instanceType  string
+		env           string
+		node          *corev1.Node
 		subRegion     string
 		osMounted     []string
 		mounted       []mount.MountPoint
@@ -1736,26 +1745,135 @@ func TestNodeGetInfo(t *testing.T) {
 			},
 			expMaxVolumes: 38,
 		},
+		{
+			name:         "Overridden by env",
+			instanceID:   "i-123456789abcdef01",
+			instanceType: "tinav6.c1r6p2",
+			subRegion:    "us-west-2b",
+			env:          "12",
+			mounted: []mount.MountPoint{
+				{Device: "overlay", Path: "/"},
+				{Device: "proc", Path: "/proc"},
+				{Device: "sysfs", Path: "/sys"},
+				{Device: "cgroup", Path: "/sys/fs/cgroup"},
+				{Device: "/dev/vda1", Path: "/csi"},
+				{Device: "udev", Path: "/dev"},
+				{Device: "devpts", Path: "/dev/pts"},
+				{Device: "tmpfs", Path: "/dev/shm"},
+				{Device: "hugetlbfs", Path: "/dev/hugepages"},
+				{Device: "mqueue", Path: "/dev/mqueue"},
+				{Device: "/dev/vda1", Path: "/etc/hosts"},
+				{Device: "/dev/vda1", Path: "/dev/termination-log"},
+				{Device: "/dev/vda1", Path: "/etc/hostname"},
+				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
+				{Device: "shm", Path: "/dev/shm"},
+				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
+				{Device: "/dev/xvdb", Path: "/data"},
+				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/plugins/kubernetes.io/csi/bsu.csi.outscale.com/foo/globalmount"},
+				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/pods/foo/volumes/kubernetes.io~csi/pvc-foo/mount"},
+			},
+			expMaxVolumes: 12,
+		},
+		{
+			name:         "Overridden by label, label has priority over env",
+			instanceID:   "i-123456789abcdef01",
+			instanceType: "tinav6.c1r6p2",
+			subRegion:    "us-west-2b",
+			env:          "12",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						NodeLimitAnnotation: "10",
+					},
+				},
+			},
+			mounted: []mount.MountPoint{
+				{Device: "overlay", Path: "/"},
+				{Device: "proc", Path: "/proc"},
+				{Device: "sysfs", Path: "/sys"},
+				{Device: "cgroup", Path: "/sys/fs/cgroup"},
+				{Device: "/dev/vda1", Path: "/csi"},
+				{Device: "udev", Path: "/dev"},
+				{Device: "devpts", Path: "/dev/pts"},
+				{Device: "tmpfs", Path: "/dev/shm"},
+				{Device: "hugetlbfs", Path: "/dev/hugepages"},
+				{Device: "mqueue", Path: "/dev/mqueue"},
+				{Device: "/dev/vda1", Path: "/etc/hosts"},
+				{Device: "/dev/vda1", Path: "/dev/termination-log"},
+				{Device: "/dev/vda1", Path: "/etc/hostname"},
+				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
+				{Device: "shm", Path: "/dev/shm"},
+				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
+				{Device: "/dev/xvdb", Path: "/data"},
+				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/plugins/kubernetes.io/csi/bsu.csi.outscale.com/foo/globalmount"},
+				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/pods/foo/volumes/kubernetes.io~csi/pvc-foo/mount"},
+			},
+			expMaxVolumes: 10,
+		},
+		{
+			name:         "Invalid label values are ignored",
+			instanceID:   "i-123456789abcdef01",
+			instanceType: "tinav6.c1r6p2",
+			subRegion:    "us-west-2b",
+			env:          "12",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						NodeLimitAnnotation: "255",
+					},
+				},
+			},
+			mounted: []mount.MountPoint{
+				{Device: "overlay", Path: "/"},
+				{Device: "proc", Path: "/proc"},
+				{Device: "sysfs", Path: "/sys"},
+				{Device: "cgroup", Path: "/sys/fs/cgroup"},
+				{Device: "/dev/vda1", Path: "/csi"},
+				{Device: "udev", Path: "/dev"},
+				{Device: "devpts", Path: "/dev/pts"},
+				{Device: "tmpfs", Path: "/dev/shm"},
+				{Device: "hugetlbfs", Path: "/dev/hugepages"},
+				{Device: "mqueue", Path: "/dev/mqueue"},
+				{Device: "/dev/vda1", Path: "/etc/hosts"},
+				{Device: "/dev/vda1", Path: "/dev/termination-log"},
+				{Device: "/dev/vda1", Path: "/etc/hostname"},
+				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
+				{Device: "shm", Path: "/dev/shm"},
+				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
+				{Device: "/dev/xvdb", Path: "/data"},
+				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/plugins/kubernetes.io/csi/bsu.csi.outscale.com/foo/globalmount"},
+				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/pods/foo/volumes/kubernetes.io~csi/pvc-foo/mount"},
+			},
+			expMaxVolumes: 12,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(MaxVolumesEnv, tc.env)
 			mockCtl := gomock.NewController(t)
 			defer mockCtl.Finish()
 
 			mockMounter := mocks.NewMockMounter(mockCtl)
-			mockMounter.EXPECT().List().Return(tc.mounted, nil)
+			mockMounter.EXPECT().List().Return(tc.mounted, nil).MaxTimes(1)
+
+			node := tc.node
+			if node == nil {
+				node = &corev1.Node{}
+			}
+			node.Name = nodeName
+			savedGetClient := k8s.GetClient
+			defer func() { k8s.GetClient = savedGetClient }()
+			k8s.GetClient = func() (kubernetes.Interface, error) {
+				return fake.NewSimpleClientset(node), nil
+			}
 
 			oscDriver := &nodeService{
 				mounter:    mockMounter,
 				instanceID: tc.instanceID,
 				subRegion:  tc.subRegion,
+				nodeName:   nodeName,
 				inFlight:   internal.NewInFlight(),
 			}
-
-			limit, err := oscDriver.getVolumesLimit()
-			require.NoError(t, err)
-			assert.Equal(t, tc.expMaxVolumes, limit)
-			oscDriver.maxVolumes = limit
 
 			resp, err := oscDriver.NodeGetInfo(context.TODO(), &csi.NodeGetInfoRequest{})
 			require.NoError(t, err)


### PR DESCRIPTION
## Description

This PR allows dynamic volume limits based on annotations.

A `bsu.csi.outscale.com/maxvolumes` annotation may be set on a node, with the volume limit for this node. It will be checked by the node driver during the NodeGetInfo call.

The limit may be dynamic if the [`MutableCSINodeAllocatableCount` feature gate](https://kubernetes.io/blog/2025/05/02/kubernetes-1-33-mutable-csi-node-allocatable-count/) is enabled.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
