### PR TITLE
✨ feat(node): reserve volume slots when computing volume limit

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -41,21 +41,33 @@ kubectl get pod -n kube-system -l "app.kubernetes.io/name=osc-bsu-csi-driver"
 
 ## Setting volume limits
 
-Up to 39 volumes, including PVCs and OS-level mounts, can be attached to a node.
+Up to 39 volumes, including PVCs and host-level mounts, can be attached to a node.
 
-The CSI driver automatically counts how many volumes are mounted by the OS and reports the calculated volume limit to Kubernetes.
+The CSI driver automatically counts how many volumes are mounted by the host and reports the calculated volume limit to Kubernetes.
 
 If the automatic calculation is not suitable, you can set a manual limit.
+
+### Reserving slots for host-level mounts
+
+If you need to mount additional volumes at the host level, you may configure the `driver.reservedBsuVolumes` Helm value with the number of expected host-level mounts (excluding the root volume).
+
+The limit reported by the CSI driver will be:
+
+`39 - max(number of mounted volumes, driver.reservedBsuVolumes)`
 
 ### Global limit
 
 The `driver.maxBsuVolumes` Helm value can be used to set a global limit. All nodes will use this value.
+
+> Note: `driver.reservedBsuVolumes` is ignored when setting `driver.maxBsuVolumes`.
 
 ### Per node limit (v1.11.0 and later)
 
 The `bsu.csi.outscale.com/maxvolumes` annotation can be set on nodes and its value will be used as the limit for the corresponding node.
 
 If both limits are set, the annotation limit takes precedence.
+
+> Note: `driver.reservedBsuVolumes` is ignored when setting an annotation limit.
 
 ### Dynamic values (v1.11.0 and later)
 

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -60,6 +60,7 @@ Kubernetes: `>=1.20`
 | driver.imagePullPolicy | string | `"IfNotPresent"` | Container image pull policy |
 | driver.maxBsuVolumes | string | `""` | Maximum number of volumes that can be attached to a node, autocomputed by default (see [Docs](https://docs.outscale.com/en/userguide/About-Volumes.html)) |
 | driver.name | string | `"bsu.csi.outscale.com"` |  |
+| driver.reservedBsuVolumes | string | `""` | Number of slots to reserve for OS-level volumes when automatically computing maxBsuVolumes |
 | driver.tag | string | `"v1.10.0"` | Container image tag to deploy |
 | imagePullSecrets | list | `[]` | Specify image pull secrets |
 | logs.format | string | `"text"` | Format of logs: text or json (requires CSI driver v1.9.0 or later) |

--- a/helm/osc-bsu-csi-driver/templates/node.yaml
+++ b/helm/osc-bsu-csi-driver/templates/node.yaml
@@ -72,6 +72,10 @@ spec:
             - name: MAX_BSU_VOLUMES
               value: "{{ .Values.driver.maxBsuVolumes }}"
           {{- end }}
+          {{- if .Values.driver.reservedBsuVolumes }}
+            - name: RESERVED_BSU_VOLUMES
+              value: "{{ .Values.driver.reservedBsuVolumes }}"
+          {{- end }}
           volumeMounts:
             - name: kubelet-dir
               mountPath: /var/lib/kubelet

--- a/helm/osc-bsu-csi-driver/values.yaml
+++ b/helm/osc-bsu-csi-driver/values.yaml
@@ -29,6 +29,8 @@ driver:
   fsGroupPolicy: File
   # -- Maximum number of volumes that can be attached to a node, autocomputed by default (see [Docs](https://docs.outscale.com/en/userguide/About-Volumes.html))
   maxBsuVolumes: ""
+  # -- Number of slots to reserve for OS-level volumes when automatically computing maxBsuVolumes
+  reservedBsuVolumes: ""
   # -- Default filesystem for the volume if no `FsType` is set in `StorageClass`
   defaultFsType: "ext4"
   # -- Enable volume snapshots

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -60,6 +60,7 @@ const (
 	NodeLimitAnnotation = DriverName + "/maxvolumes"
 	NodeNameEnv         = "NODE_NAME"
 	MaxVolumesEnv       = "MAX_BSU_VOLUMES"
+	ReservedVolumesEnv  = "RESERVED_BSU_VOLUMES"
 )
 
 var ValidFSTypes = []string{FSTypeExt2, FSTypeExt3, FSTypeExt4, FSTypeXfs}
@@ -810,7 +811,7 @@ func (s *nodeService) getVolumesLimit(ctx context.Context) (int64, error) {
 	}
 
 	// checking env
-	maxVolumes := getEnvMaxVolume()
+	maxVolumes := getEnvMaxVolumes()
 	if maxVolumes > 0 {
 		klog.FromContext(ctx).V(3).Info("Setting limit from env", "maxVolumes", maxVolumes)
 		return maxVolumes, nil
@@ -834,12 +835,14 @@ func (s *nodeService) getVolumesLimit(ctx context.Context) (int64, error) {
 			devs = append(devs, m.Device)
 		}
 	}
-	maxVolumes = defaultMaxBSUVolumes - int64(len(devs))
+	// devs includes the root volume
+	// we need to reserve getEnvReservedVolumes() + the root volume
+	maxVolumes = defaultMaxBSUVolumes - max(int64(len(devs)), getEnvReservedVolumes()+1)
 	klog.FromContext(ctx).V(3).Info("Computed limit", "maxVolumes", maxVolumes)
 	return maxVolumes, nil
 }
 
-func getEnvMaxVolume() int64 {
+func getEnvMaxVolumes() int64 {
 	value := os.Getenv(MaxVolumesEnv)
 	if value == "" {
 		return -1
@@ -849,6 +852,18 @@ func getEnvMaxVolume() int64 {
 		return -1
 	}
 	return int64(maxValue)
+}
+
+func getEnvReservedVolumes() int64 {
+	value := os.Getenv(ReservedVolumesEnv)
+	if value == "" {
+		return 0
+	}
+	reservedValue, err := strconv.Atoi(value)
+	if err != nil {
+		return 0
+	}
+	return int64(reservedValue)
 }
 
 // hasMountOption returns a boolean indicating whether the given

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1634,6 +1634,7 @@ func TestNodeGetInfo(t *testing.T) {
 		instanceID    string
 		instanceType  string
 		env           string
+		envReserved   string
 		node          *corev1.Node
 		subRegion     string
 		osMounted     []string
@@ -1716,6 +1717,33 @@ func TestNodeGetInfo(t *testing.T) {
 				{Device: "/dev/sdb", Path: "/data"},
 			},
 			expMaxVolumes: 38,
+		},
+		{
+			name:         "1 OS mounted volume on sdb, no PVC, 2 reserved",
+			instanceID:   "i-123456789abcdef01",
+			instanceType: "tinav6.c1r6p2",
+			subRegion:    "us-west-2b",
+			envReserved:  "2",
+			mounted: []mount.MountPoint{
+				{Device: "overlay", Path: "/"},
+				{Device: "proc", Path: "/proc"},
+				{Device: "sysfs", Path: "/sys"},
+				{Device: "cgroup", Path: "/sys/fs/cgroup"},
+				{Device: "/dev/vda1", Path: "/csi"},
+				{Device: "udev", Path: "/dev"},
+				{Device: "devpts", Path: "/dev/pts"},
+				{Device: "tmpfs", Path: "/dev/shm"},
+				{Device: "hugetlbfs", Path: "/dev/hugepages"},
+				{Device: "mqueue", Path: "/dev/mqueue"},
+				{Device: "/dev/vda1", Path: "/etc/hosts"},
+				{Device: "/dev/vda1", Path: "/dev/termination-log"},
+				{Device: "/dev/vda1", Path: "/etc/hostname"},
+				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
+				{Device: "shm", Path: "/dev/shm"},
+				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
+				{Device: "/dev/sdb", Path: "/data"},
+			},
+			expMaxVolumes: 37,
 		},
 		{
 			name:         "1 OS mounted volume on xvdb, 1 PVC",
@@ -1850,6 +1878,7 @@ func TestNodeGetInfo(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Setenv(MaxVolumesEnv, tc.env)
+			t.Setenv(ReservedVolumesEnv, tc.envReserved)
 			mockCtl := gomock.NewController(t)
 			defer mockCtl.Finish()
 


### PR DESCRIPTION
## Description

This PR adds a new `driver.reservedBsuVolumes` helm value that allows setting a number of reserved slots for OS level mounts.

`driver.reservedBsuVolumes` will be substracted to the automatic calculation of the number of allowed volumes for a node.

The maximum number of volumes for a node is: `39 - max(number of OS level mounted volumes (excluding the root volume), driver.reservedBsuVolumes)`

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
