### PR TITLE
♻️ refacto(NodeGetInfo): call metatada to list attached volumes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0
 	github.com/outscale/goutils/k8s v0.0.2
-	github.com/outscale/goutils/sdk v0.0.2
+	github.com/outscale/goutils/sdk v0.0.4
 	github.com/outscale/osc-sdk-go/v3 v3.0.0-rc.2
 	github.com/rs/xid v1.6.0
 	github.com/samber/lo v1.53.0
@@ -32,8 +32,9 @@ require (
 
 // replace (
 // 	github.com/outscale/goutils/k8s => ../goutils/k8s
-// 	github.com/outscale/goutils/sdk => ../goutils/sdk
+//  github.com/outscale/goutils/sdk => ../goutils/sdk
 // )
+
 replace github.com/kubernetes-csi/csi-test/v5 v5.4.0 => github.com/outscale/kubernetes-csi-test/v5 v5.4.0-outscale
 
 require (
@@ -71,6 +72,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jarcoal/httpmock v1.4.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVU
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jarcoal/httpmock v1.4.1 h1:0Ju+VCFuARfFlhVXFc2HxlcQkfB+Xq12/EotHko+x2A=
+github.com/jarcoal/httpmock v1.4.1/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
@@ -121,6 +123,8 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/maxatome/go-testdeep v1.14.0 h1:rRlLv1+kI8eOI3OaBXZwb3O7xY3exRzdW5QyX48g9wI=
+github.com/maxatome/go-testdeep v1.14.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/mfridman/tparse v0.18.0 h1:wh6dzOKaIwkUGyKgOntDW4liXSo37qg5AXbIhkMV3vE=
 github.com/mfridman/tparse v0.18.0/go.mod h1:gEvqZTuCgEhPbYk/2lS3Kcxg1GmTxxU7kTC8DvP0i/A=
 github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
@@ -149,8 +153,8 @@ github.com/opencontainers/selinux v1.11.1 h1:nHFvthhM0qY8/m+vfhJylliSshm8G1jJ2jD
 github.com/opencontainers/selinux v1.11.1/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
 github.com/outscale/goutils/k8s v0.0.2 h1:GkYQu4qIIB09PAEOiD0fXZCFVKbPfOTr1cMIFsPzrg0=
 github.com/outscale/goutils/k8s v0.0.2/go.mod h1:tTa+38LngOZfihy3b6to2lTTqsohk+OKTRD9H2/ytGI=
-github.com/outscale/goutils/sdk v0.0.2 h1:btnhPmo2Sitm3PDtE4bBeuFpF0B4YEHUc91NT7rsVPM=
-github.com/outscale/goutils/sdk v0.0.2/go.mod h1:2Ae3lIQmdOC+n/VnOABrzS+kpjq/Hm0PJQhABpiFW8M=
+github.com/outscale/goutils/sdk v0.0.4 h1:hm+LZyeHUBYj066MjVVYYEPnlZRQSv4v74TZgfIQkRM=
+github.com/outscale/goutils/sdk v0.0.4/go.mod h1:LiXmAIA3CAXCdanEARKQ3Q/Lb8n8dKeGSbPRxIe43kc=
 github.com/outscale/kubernetes-csi-test/v5 v5.4.0-outscale h1:WB9CqCemzvwM7VIf3JYL4Y+gnFWCS/pisVBCNWmIqnQ=
 github.com/outscale/kubernetes-csi-test/v5 v5.4.0-outscale/go.mod h1:anAJKFUb/SdHhIHECgSKxC5LSiLzib+1I6mrWF5Hve8=
 github.com/outscale/osc-sdk-go/v3 v3.0.0-rc.2 h1:uj8s4jaqqzq2hFqQVAB6PTVwuPm43e5Ti/ZFQqvCAB0=
@@ -275,8 +279,6 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -353,8 +355,6 @@ k8s.io/mount-utils v0.34.7 h1:hQRFQ/+MYySd/ZmasWE/MUJsQz5/2BNMZ6EJFX1QxVg=
 k8s.io/mount-utils v0.34.7/go.mod h1:DY1x4o9KaP9fXkHeWCOFWmhRdvKD8nzJ7K57xE5T95c=
 k8s.io/pod-security-admission v0.34.7 h1:yfy/+AyLVcFIyu+g9F3/Hvva6JRPC5PYJH993nA8Voc=
 k8s.io/pod-security-admission v0.34.7/go.mod h1:KjypUfPxNzTAQab3tqF/QmVxQWqnlP0OvfUtj31FX/E=
-k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 h1:kBawHLSnx/mYHmRnNUf9d4CpjREbeZuxoSGOX/J+aYM=
-k8s.io/utils v0.0.0-20260319190234-28399d86e0b5/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 k8s.io/utils v0.0.0-20260507154919-ff6756f316d2 h1:wU4tMEhLGgIbLvXQb1cfN+EcM0wf7zC6CPF+C79jroc=
 k8s.io/utils v0.0.0-20260507154919-ff6756f316d2/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 h1:hSfpvjjTQXQY2Fol2CS0QHMNs/WI1MOSGzCm1KhM5ec=

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -31,6 +31,7 @@ import (
 	"github.com/outscale/osc-bsu-csi-driver/pkg/driver/internal"
 	"github.com/outscale/osc-bsu-csi-driver/pkg/driver/k8s"
 	"github.com/outscale/osc-bsu-csi-driver/pkg/driver/luks"
+	"github.com/samber/lo"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -101,7 +102,7 @@ func newNodeService(ctx context.Context, driverOptions *DriverOptions) (nodeServ
 	if err != nil {
 		return nodeService{}, err
 	}
-	srv.subRegion, err = metadata.GetSubRegion(ctx)
+	srv.subRegion, err = metadata.GetSubregion(ctx)
 	if err != nil {
 		return nodeService{}, err
 	}
@@ -819,24 +820,13 @@ func (s *nodeService) getVolumesLimit(ctx context.Context) (int64, error) {
 		return maxVolumes, nil
 	}
 
-	// count mounted devices
-	mounts, err := s.mounter.List()
+	// count attached volumes
+	mappings, err := metadata.GetDeviceMappings(ctx)
 	if err != nil {
-		return -1, fmt.Errorf("list mounts: %w", err)
+		return -1, fmt.Errorf("list device mappings: %w", err)
 	}
-	devs := make([]string, 0, len(mounts))
-	for _, m := range mounts {
-		// skip non devices
-		if !strings.HasPrefix(m.Device, "/dev/xvd") &&
-			!strings.HasPrefix(m.Device, "/dev/vd") &&
-			!strings.HasPrefix(m.Device, "/dev/sd") {
-			continue
-		}
-		if !slices.Contains(devs, m.Device) {
-			devs = append(devs, m.Device)
-		}
-	}
-	logger.V(4).Info("Mounted volumes", "count", len(devs))
+	volumes := len(lo.UniqValues(mappings))
+	logger.V(4).Info("Attached volumes", "count", volumes)
 
 	// count PVC
 	pvcs, err := k8s.CountVolumeAttachments(ctx, s.nodeName, DriverName)
@@ -848,7 +838,7 @@ func (s *nodeService) getVolumesLimit(ctx context.Context) (int64, error) {
 
 	// devs includes the root volume
 	// we need to reserve getEnvReservedVolumes() + the root volume
-	maxVolumes = defaultMaxBSUVolumes - max(int64(len(devs)-pvcs), getEnvReservedVolumes()+1)
+	maxVolumes = defaultMaxBSUVolumes - max(int64(volumes-pvcs), getEnvReservedVolumes()+1)
 	logger.V(3).Info("Computed limit", "maxVolumes", maxVolumes)
 	return maxVolumes, nil
 }

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/outscale/goutils/sdk/metadata/mocks_metadata"
 	"github.com/outscale/osc-bsu-csi-driver/pkg/driver/internal"
 	"github.com/outscale/osc-bsu-csi-driver/pkg/driver/k8s"
 	"github.com/outscale/osc-bsu-csi-driver/pkg/driver/luks"
@@ -40,7 +41,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	exec "k8s.io/utils/exec"
-	"k8s.io/utils/mount"
 )
 
 const nodeName = "node-foo"
@@ -1640,110 +1640,34 @@ func TestNodeGetInfo(t *testing.T) {
 		objs          []runtime.Object
 		subRegion     string
 		osMounted     []string
-		mounted       []mount.MountPoint
+		mappings      map[string]string
 		expMaxVolumes int64
 	}{
 		{
-			name:         "default mounts, no pvc",
-			instanceID:   "i-123456789abcdef01",
-			instanceType: "tinav6.c1r6p2",
-			subRegion:    "us-west-2b",
-			mounted: []mount.MountPoint{
-				{Device: "overlay", Path: "/"},
-				{Device: "proc", Path: "/proc"},
-				{Device: "sysfs", Path: "/sys"},
-				{Device: "cgroup", Path: "/sys/fs/cgroup"},
-				{Device: "/dev/vda1", Path: "/csi"},
-				{Device: "udev", Path: "/dev"},
-				{Device: "devpts", Path: "/dev/pts"},
-				{Device: "tmpfs", Path: "/dev/shm"},
-				{Device: "hugetlbfs", Path: "/dev/hugepages"},
-				{Device: "mqueue", Path: "/dev/mqueue"},
-				{Device: "/dev/vda1", Path: "/etc/hosts"},
-				{Device: "/dev/vda1", Path: "/dev/termination-log"},
-				{Device: "/dev/vda1", Path: "/etc/hostname"},
-				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
-				{Device: "shm", Path: "/dev/shm"},
-				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
-			},
+			name:          "default mounts, no pvc",
+			instanceID:    "i-123456789abcdef01",
+			instanceType:  "tinav6.c1r6p2",
+			subRegion:     "us-west-2b",
 			expMaxVolumes: 39,
 		},
 		{
-			name:         "1 OS mounted volume on xvdb, no PVC",
+			name:         "1 OS mounted volume, no PVC",
 			instanceID:   "i-123456789abcdef01",
 			instanceType: "tinav6.c1r6p2",
 			subRegion:    "us-west-2b",
-			mounted: []mount.MountPoint{
-				{Device: "overlay", Path: "/"},
-				{Device: "proc", Path: "/proc"},
-				{Device: "sysfs", Path: "/sys"},
-				{Device: "cgroup", Path: "/sys/fs/cgroup"},
-				{Device: "/dev/vda1", Path: "/csi"},
-				{Device: "udev", Path: "/dev"},
-				{Device: "devpts", Path: "/dev/pts"},
-				{Device: "tmpfs", Path: "/dev/shm"},
-				{Device: "hugetlbfs", Path: "/dev/hugepages"},
-				{Device: "mqueue", Path: "/dev/mqueue"},
-				{Device: "/dev/vda1", Path: "/etc/hosts"},
-				{Device: "/dev/vda1", Path: "/dev/termination-log"},
-				{Device: "/dev/vda1", Path: "/etc/hostname"},
-				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
-				{Device: "shm", Path: "/dev/shm"},
-				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
-				{Device: "/dev/xvdb", Path: "/data"},
+			mappings: map[string]string{
+				"ebs0": "/dev/xvdb",
 			},
 			expMaxVolumes: 38,
 		},
 		{
-			name:         "1 OS mounted volume on sdb, no PVC",
-			instanceID:   "i-123456789abcdef01",
-			instanceType: "tinav6.c1r6p2",
-			subRegion:    "us-west-2b",
-			mounted: []mount.MountPoint{
-				{Device: "overlay", Path: "/"},
-				{Device: "proc", Path: "/proc"},
-				{Device: "sysfs", Path: "/sys"},
-				{Device: "cgroup", Path: "/sys/fs/cgroup"},
-				{Device: "/dev/vda1", Path: "/csi"},
-				{Device: "udev", Path: "/dev"},
-				{Device: "devpts", Path: "/dev/pts"},
-				{Device: "tmpfs", Path: "/dev/shm"},
-				{Device: "hugetlbfs", Path: "/dev/hugepages"},
-				{Device: "mqueue", Path: "/dev/mqueue"},
-				{Device: "/dev/vda1", Path: "/etc/hosts"},
-				{Device: "/dev/vda1", Path: "/dev/termination-log"},
-				{Device: "/dev/vda1", Path: "/etc/hostname"},
-				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
-				{Device: "shm", Path: "/dev/shm"},
-				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
-				{Device: "/dev/sdb", Path: "/data"},
-			},
-			expMaxVolumes: 38,
-		},
-		{
-			name:         "1 OS mounted volume on sdb, no PVC, 2 reserved",
+			name:         "1 OS mounted volume, no PVC, 2 reserved",
 			instanceID:   "i-123456789abcdef01",
 			instanceType: "tinav6.c1r6p2",
 			subRegion:    "us-west-2b",
 			envReserved:  "2",
-			mounted: []mount.MountPoint{
-				{Device: "overlay", Path: "/"},
-				{Device: "proc", Path: "/proc"},
-				{Device: "sysfs", Path: "/sys"},
-				{Device: "cgroup", Path: "/sys/fs/cgroup"},
-				{Device: "/dev/vda1", Path: "/csi"},
-				{Device: "udev", Path: "/dev"},
-				{Device: "devpts", Path: "/dev/pts"},
-				{Device: "tmpfs", Path: "/dev/shm"},
-				{Device: "hugetlbfs", Path: "/dev/hugepages"},
-				{Device: "mqueue", Path: "/dev/mqueue"},
-				{Device: "/dev/vda1", Path: "/etc/hosts"},
-				{Device: "/dev/vda1", Path: "/dev/termination-log"},
-				{Device: "/dev/vda1", Path: "/etc/hostname"},
-				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
-				{Device: "shm", Path: "/dev/shm"},
-				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
-				{Device: "/dev/sdb", Path: "/data"},
+			mappings: map[string]string{
+				"ebs0": "/dev/xvdb",
 			},
 			expMaxVolumes: 37,
 		},
@@ -1758,26 +1682,9 @@ func TestNodeGetInfo(t *testing.T) {
 					Status: storagev1.VolumeAttachmentStatus{Attached: true},
 				},
 			},
-			mounted: []mount.MountPoint{
-				{Device: "overlay", Path: "/"},
-				{Device: "proc", Path: "/proc"},
-				{Device: "sysfs", Path: "/sys"},
-				{Device: "cgroup", Path: "/sys/fs/cgroup"},
-				{Device: "/dev/vda1", Path: "/csi"},
-				{Device: "udev", Path: "/dev"},
-				{Device: "devpts", Path: "/dev/pts"},
-				{Device: "tmpfs", Path: "/dev/shm"},
-				{Device: "hugetlbfs", Path: "/dev/hugepages"},
-				{Device: "mqueue", Path: "/dev/mqueue"},
-				{Device: "/dev/vda1", Path: "/etc/hosts"},
-				{Device: "/dev/vda1", Path: "/dev/termination-log"},
-				{Device: "/dev/vda1", Path: "/etc/hostname"},
-				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
-				{Device: "shm", Path: "/dev/shm"},
-				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
-				{Device: "/dev/xvdb", Path: "/data"},
-				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/plugins/kubernetes.io/csi/bsu.csi.outscale.com/foo/globalmount"},
-				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/pods/foo/volumes/kubernetes.io~csi/pvc-foo/mount"},
+			mappings: map[string]string{
+				"ebs0": "/dev/xvdb",
+				"ebs1": "/dev/xvdc",
 			},
 			expMaxVolumes: 38,
 		},
@@ -1792,26 +1699,9 @@ func TestNodeGetInfo(t *testing.T) {
 					Status: storagev1.VolumeAttachmentStatus{Attached: true},
 				},
 			},
-			mounted: []mount.MountPoint{
-				{Device: "overlay", Path: "/"},
-				{Device: "proc", Path: "/proc"},
-				{Device: "sysfs", Path: "/sys"},
-				{Device: "cgroup", Path: "/sys/fs/cgroup"},
-				{Device: "/dev/vda1", Path: "/csi"},
-				{Device: "udev", Path: "/dev"},
-				{Device: "devpts", Path: "/dev/pts"},
-				{Device: "tmpfs", Path: "/dev/shm"},
-				{Device: "hugetlbfs", Path: "/dev/hugepages"},
-				{Device: "mqueue", Path: "/dev/mqueue"},
-				{Device: "/dev/vda1", Path: "/etc/hosts"},
-				{Device: "/dev/vda1", Path: "/dev/termination-log"},
-				{Device: "/dev/vda1", Path: "/etc/hostname"},
-				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
-				{Device: "shm", Path: "/dev/shm"},
-				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
-				{Device: "/dev/xvdb", Path: "/data"},
-				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/plugins/kubernetes.io/csi/bsu.csi.outscale.com/foo/globalmount"},
-				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/pods/foo/volumes/kubernetes.io~csi/pvc-foo/mount"},
+			mappings: map[string]string{
+				"ebs0": "/dev/xvdb",
+				"ebs1": "/dev/xvdc",
 			},
 			expMaxVolumes: 37,
 		},
@@ -1826,24 +1716,8 @@ func TestNodeGetInfo(t *testing.T) {
 					Status: storagev1.VolumeAttachmentStatus{Attached: true},
 				},
 			},
-			mounted: []mount.MountPoint{
-				{Device: "overlay", Path: "/"},
-				{Device: "proc", Path: "/proc"},
-				{Device: "sysfs", Path: "/sys"},
-				{Device: "cgroup", Path: "/sys/fs/cgroup"},
-				{Device: "/dev/vda1", Path: "/csi"},
-				{Device: "udev", Path: "/dev"},
-				{Device: "devpts", Path: "/dev/pts"},
-				{Device: "tmpfs", Path: "/dev/shm"},
-				{Device: "hugetlbfs", Path: "/dev/hugepages"},
-				{Device: "mqueue", Path: "/dev/mqueue"},
-				{Device: "/dev/vda1", Path: "/etc/hosts"},
-				{Device: "/dev/vda1", Path: "/dev/termination-log"},
-				{Device: "/dev/vda1", Path: "/etc/hostname"},
-				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
-				{Device: "shm", Path: "/dev/shm"},
-				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
-				{Device: "/dev/xvdb", Path: "/data"},
+			mappings: map[string]string{
+				"ebs0": "/dev/xvdb",
 			},
 			expMaxVolumes: 38,
 		},
@@ -1858,24 +1732,8 @@ func TestNodeGetInfo(t *testing.T) {
 					Status: storagev1.VolumeAttachmentStatus{Attached: false},
 				},
 			},
-			mounted: []mount.MountPoint{
-				{Device: "overlay", Path: "/"},
-				{Device: "proc", Path: "/proc"},
-				{Device: "sysfs", Path: "/sys"},
-				{Device: "cgroup", Path: "/sys/fs/cgroup"},
-				{Device: "/dev/vda1", Path: "/csi"},
-				{Device: "udev", Path: "/dev"},
-				{Device: "devpts", Path: "/dev/pts"},
-				{Device: "tmpfs", Path: "/dev/shm"},
-				{Device: "hugetlbfs", Path: "/dev/hugepages"},
-				{Device: "mqueue", Path: "/dev/mqueue"},
-				{Device: "/dev/vda1", Path: "/etc/hosts"},
-				{Device: "/dev/vda1", Path: "/dev/termination-log"},
-				{Device: "/dev/vda1", Path: "/etc/hostname"},
-				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
-				{Device: "shm", Path: "/dev/shm"},
-				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
-				{Device: "/dev/xvdb", Path: "/data"},
+			mappings: map[string]string{
+				"ebs0": "/dev/xvdb",
 			},
 			expMaxVolumes: 38,
 		},
@@ -1891,26 +1749,9 @@ func TestNodeGetInfo(t *testing.T) {
 					Status: storagev1.VolumeAttachmentStatus{Attached: true},
 				},
 			},
-			mounted: []mount.MountPoint{
-				{Device: "overlay", Path: "/"},
-				{Device: "proc", Path: "/proc"},
-				{Device: "sysfs", Path: "/sys"},
-				{Device: "cgroup", Path: "/sys/fs/cgroup"},
-				{Device: "/dev/vda1", Path: "/csi"},
-				{Device: "udev", Path: "/dev"},
-				{Device: "devpts", Path: "/dev/pts"},
-				{Device: "tmpfs", Path: "/dev/shm"},
-				{Device: "hugetlbfs", Path: "/dev/hugepages"},
-				{Device: "mqueue", Path: "/dev/mqueue"},
-				{Device: "/dev/vda1", Path: "/etc/hosts"},
-				{Device: "/dev/vda1", Path: "/dev/termination-log"},
-				{Device: "/dev/vda1", Path: "/etc/hostname"},
-				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
-				{Device: "shm", Path: "/dev/shm"},
-				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
-				{Device: "/dev/xvdb", Path: "/data"},
-				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/plugins/kubernetes.io/csi/bsu.csi.outscale.com/foo/globalmount"},
-				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/pods/foo/volumes/kubernetes.io~csi/pvc-foo/mount"},
+			mappings: map[string]string{
+				"ebs0": "/dev/xvdb",
+				"ebs1": "/dev/xvdc",
 			},
 			expMaxVolumes: 12,
 		},
@@ -1934,26 +1775,9 @@ func TestNodeGetInfo(t *testing.T) {
 					Status: storagev1.VolumeAttachmentStatus{Attached: true},
 				},
 			},
-			mounted: []mount.MountPoint{
-				{Device: "overlay", Path: "/"},
-				{Device: "proc", Path: "/proc"},
-				{Device: "sysfs", Path: "/sys"},
-				{Device: "cgroup", Path: "/sys/fs/cgroup"},
-				{Device: "/dev/vda1", Path: "/csi"},
-				{Device: "udev", Path: "/dev"},
-				{Device: "devpts", Path: "/dev/pts"},
-				{Device: "tmpfs", Path: "/dev/shm"},
-				{Device: "hugetlbfs", Path: "/dev/hugepages"},
-				{Device: "mqueue", Path: "/dev/mqueue"},
-				{Device: "/dev/vda1", Path: "/etc/hosts"},
-				{Device: "/dev/vda1", Path: "/dev/termination-log"},
-				{Device: "/dev/vda1", Path: "/etc/hostname"},
-				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
-				{Device: "shm", Path: "/dev/shm"},
-				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
-				{Device: "/dev/xvdb", Path: "/data"},
-				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/plugins/kubernetes.io/csi/bsu.csi.outscale.com/foo/globalmount"},
-				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/pods/foo/volumes/kubernetes.io~csi/pvc-foo/mount"},
+			mappings: map[string]string{
+				"ebs0": "/dev/xvdb",
+				"ebs1": "/dev/xvdc",
 			},
 			expMaxVolumes: 10,
 		},
@@ -1977,26 +1801,9 @@ func TestNodeGetInfo(t *testing.T) {
 					Status: storagev1.VolumeAttachmentStatus{Attached: true},
 				},
 			},
-			mounted: []mount.MountPoint{
-				{Device: "overlay", Path: "/"},
-				{Device: "proc", Path: "/proc"},
-				{Device: "sysfs", Path: "/sys"},
-				{Device: "cgroup", Path: "/sys/fs/cgroup"},
-				{Device: "/dev/vda1", Path: "/csi"},
-				{Device: "udev", Path: "/dev"},
-				{Device: "devpts", Path: "/dev/pts"},
-				{Device: "tmpfs", Path: "/dev/shm"},
-				{Device: "hugetlbfs", Path: "/dev/hugepages"},
-				{Device: "mqueue", Path: "/dev/mqueue"},
-				{Device: "/dev/vda1", Path: "/etc/hosts"},
-				{Device: "/dev/vda1", Path: "/dev/termination-log"},
-				{Device: "/dev/vda1", Path: "/etc/hostname"},
-				{Device: "/dev/vda1", Path: "/etc/resolv.conf"},
-				{Device: "shm", Path: "/dev/shm"},
-				{Device: "/dev/vda1", Path: "/var/lib/kubelet"},
-				{Device: "/dev/xvdb", Path: "/data"},
-				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/plugins/kubernetes.io/csi/bsu.csi.outscale.com/foo/globalmount"},
-				{Device: "/dev/xvdc", Path: "/var/lib/kubelet/pods/foo/volumes/kubernetes.io~csi/pvc-foo/mount"},
+			mappings: map[string]string{
+				"ebs0": "/dev/xvdb",
+				"ebs1": "/dev/xvdc",
 			},
 			expMaxVolumes: 12,
 		},
@@ -2008,8 +1815,10 @@ func TestNodeGetInfo(t *testing.T) {
 			mockCtl := gomock.NewController(t)
 			defer mockCtl.Finish()
 
-			mockMounter := mocks.NewMockMounter(mockCtl)
-			mockMounter.EXPECT().List().Return(tc.mounted, nil).MaxTimes(1)
+			mocks_metadata.Setup()
+			defer mocks_metadata.Teardown()
+
+			mocks_metadata.MockDevideMappings(tc.mappings)
 
 			objs := tc.objs
 			if len(objs) == 0 {
@@ -2024,7 +1833,6 @@ func TestNodeGetInfo(t *testing.T) {
 			}
 
 			oscDriver := &nodeService{
-				mounter:    mockMounter,
 				instanceID: tc.instanceID,
 				subRegion:  tc.subRegion,
 				nodeName:   nodeName,


### PR DESCRIPTION
## Description

NodeGetInfo needs to compute the maximum number of mountable volumes.

The list of attached volumes was computed by listing mounted volumes, which was not exact (a volume can be attached but not mounted). This PR uses metadata calls to do the computation.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
