### PR TITLE
🧵 fix(race): race condition in ControllerPublishVolume

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -345,40 +346,36 @@ func (c *cloud) DeleteVolume(ctx context.Context, volumeID string) (bool, error)
 }
 
 func (c *cloud) AttachVolume(ctx context.Context, volumeID, nodeID string) (string, error) {
-	instance, err := c.getInstance(ctx, nodeID)
+	vm, err := c.getVm(ctx, nodeID)
 	if err != nil {
 		return "", err
 	}
 
-	device, err := c.dm.NewDevice(instance, volumeID)
+	device, err := c.dm.AssignDevice(ctx, vm, volumeID)
 	if err != nil {
 		return "", err
 	}
-	defer device.Release(false)
 
-	if !device.IsAlreadyAssigned {
+	if !device.Linked() {
 		request := osc.LinkVolumeRequest{
-			DeviceName: device.Path,
+			DeviceName: device.Path(),
 			VmId:       nodeID,
 			VolumeId:   volumeID,
 		}
 		_, err := c.client.LinkVolume(ctx, request)
 		if err != nil {
+			c.dm.Release(ctx, vm, volumeID)
 			return "", fmt.Errorf("attach volume: %w", err)
 		}
+		device.MarkAsLinked()
 	}
 
-	// This is the only situation where we taint the device
+	// Wait for the volume to be properly attached.
 	if err := c.waitForAttachedVolume(ctx, volumeID); err != nil {
-		device.Taint()
 		return "", err
 	}
 
-	// TODO: Double check the attachment to be 100% sure we attached the correct volume at the correct mountpoint
-	// It could happen otherwise that we see the volume attached from a previous/separate AttachVolume call,
-	// which could theoretically be against a different device (or even instance).
-
-	return device.Path, nil
+	return device.Path(), nil
 }
 
 // waitForAttachedVolume waits for volume to be attached state.
@@ -404,48 +401,43 @@ func (c *cloud) waitForAttachedVolume(ctx context.Context, volumeID string) erro
 
 func (c *cloud) DetachVolume(ctx context.Context, volumeID, nodeID string) error {
 	logger := klog.FromContext(ctx)
-	{
-		// Check if the volume is attached to VM
-		request := osc.ReadVolumesRequest{
-			Filters: &osc.FiltersVolume{
-				VolumeIds: &[]string{volumeID},
-			},
-		}
 
-		volume, err := c.getVolume(ctx, request)
-		if err == nil && volume.State == osc.VolumeStateAvailable {
-			logger.V(4).Info("Volume is already available")
-			return nil
-		}
-	}
-	instance, err := c.getInstance(ctx, nodeID)
+	vm, err := c.getVm(ctx, nodeID)
 	if err != nil {
 		return err
 	}
 
-	// TODO: check if attached
-	device := c.dm.GetDevice(instance, volumeID)
-	defer device.Release(true)
-
-	if !device.IsAlreadyAssigned {
-		logger.V(4).Info("Volume is not assigned to node")
-		return ErrNotFound
+	// Check if the volume is attached to VM
+	volume, err := c.getVolume(ctx, osc.ReadVolumesRequest{
+		Filters: &osc.FiltersVolume{
+			VolumeIds: &[]string{volumeID},
+		},
+	})
+	switch {
+	case errors.Is(err, ErrNotFound):
+		return nil
+	case err != nil:
+		return fmt.Errorf("read volume: %w", err)
+	case volume.State != osc.VolumeStateInUse:
+		logger.V(4).Info("Volume is not linked")
+		return nil
+	case !slices.ContainsFunc(volume.LinkedVolumes, func(l osc.LinkedVolume) bool {
+		return l.VmId == vm.VmId
+	}):
+		logger.V(3).Info("Volume is linked to another VM, ignoring")
+		return nil
 	}
 
 	request := osc.UnlinkVolumeRequest{
 		VolumeId: volumeID,
 	}
-
 	_, err = c.client.UnlinkVolume(ctx, request)
 	if err != nil {
 		return fmt.Errorf("detach volume: %w", err)
 	}
-
-	if err := c.waitForDetachedVolume(ctx, volumeID); err != nil {
-		return err
-	}
-
-	return nil
+	err = c.waitForDetachedVolume(ctx, volumeID)
+	c.dm.Release(ctx, vm, volumeID)
+	return err
 }
 
 // waitForDetachedVolume waits for volume to be attached state.
@@ -522,7 +514,7 @@ func (c *cloud) GetVolumeByID(ctx context.Context, volumeID string) (*Volume, er
 
 // FiXME: errors are not properly handled.
 func (c *cloud) ExistsInstance(ctx context.Context, nodeID string) bool {
-	_, err := c.getInstance(ctx, nodeID)
+	_, err := c.getVm(ctx, nodeID)
 	return err == nil
 }
 
@@ -716,7 +708,7 @@ func (c *cloud) getVolume(ctx context.Context, request osc.ReadVolumesRequest) (
 }
 
 // Pagination not supported
-func (c *cloud) getInstance(ctx context.Context, vmID string) (*osc.Vm, error) {
+func (c *cloud) getVm(ctx context.Context, vmID string) (*osc.Vm, error) {
 	resp, err := c.client.ReadVms(ctx, osc.ReadVmsRequest{
 		Filters: &osc.FiltersVm{
 			VmIds: &[]string{vmID},

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -426,7 +426,9 @@ func TestDetachVolume(t *testing.T) {
 				LinkedVolumes: nil,
 				State:         tc.initial,
 			}
-
+			if tc.initial == osc.VolumeStateInUse {
+				vol.LinkedVolumes = []osc.LinkedVolume{{VmId: tc.nodeID}}
+			}
 			// Create a Vm and add device in BSU
 			vm := newDescribeInstancesOutput(tc.nodeID)
 			devicePath := "/dev/sdb"
@@ -438,19 +440,20 @@ func TestDetachVolume(t *testing.T) {
 					},
 				},
 			}
+			mockOscInterface.EXPECT().ReadVms(gomock.Any(), gomock.Eq(osc.ReadVmsRequest{
+				Filters: &osc.FiltersVm{VmIds: &[]string{tc.nodeID}},
+			})).Return(vm, nil)
 			mockOscInterface.EXPECT().ReadVolumes(gomock.Any(), gomock.Eq(osc.ReadVolumesRequest{
 				Filters: &osc.FiltersVolume{VolumeIds: &[]string{tc.volumeID}},
 			})).Return(&osc.ReadVolumesResponse{Volumes: &[]osc.Volume{vol}}, nil)
 			if tc.initial == osc.VolumeStateInUse {
-				mockOscInterface.EXPECT().ReadVms(gomock.Any(), gomock.Eq(osc.ReadVmsRequest{
-					Filters: &osc.FiltersVm{VmIds: &[]string{tc.nodeID}},
-				})).Return(vm, nil)
 				mockOscInterface.EXPECT().UnlinkVolume(gomock.Any(), gomock.Eq(osc.UnlinkVolumeRequest{
 					VolumeId: tc.volumeID,
 				})).Return(&osc.UnlinkVolumeResponse{}, tc.expErr)
 				if tc.expErr == nil {
 					detached := vol
 					detached.State = osc.VolumeStateAvailable
+					detached.LinkedVolumes = nil
 					mockOscInterface.EXPECT().ReadVolumes(gomock.Any(), gomock.Eq(osc.ReadVolumesRequest{
 						Filters:        &osc.FiltersVolume{VolumeIds: &[]string{tc.volumeID}},
 						ResultsPerPage: ptr.To(1),
@@ -1202,9 +1205,12 @@ func newCloud(mock *mocks_osc.MockClient) *cloud {
 
 func newDescribeInstancesOutput(nodeID string) *osc.ReadVmsResponse {
 	return &osc.ReadVmsResponse{
-		Vms: &[]osc.Vm{
-			{VmId: nodeID},
-		},
+		Vms: &[]osc.Vm{{
+			VmId: nodeID,
+			BlockDeviceMappings: []osc.BlockDeviceMappingCreated{{
+				DeviceName: "/dev/sda",
+			}},
+		}},
 	}
 }
 

--- a/pkg/cloud/devicemanager/allocator.go
+++ b/pkg/cloud/devicemanager/allocator.go
@@ -16,43 +16,35 @@ limitations under the License.
 
 package devicemanager
 
-import "errors"
+import (
+	"errors"
+	"slices"
+)
 
-// ExistingNames is a map of assigned device names. Presence of a key with a device
-// name in the map means that the device is allocated. Value is irrelevant and
-// can be used for anything that NameAllocator user wants.  Only the relevant
-// part of device name should be in the map, e.g. "ba" for "/dev/xvdba".
-type ExistingNames map[string]string
-
-// On Outscale, we should assign new (not yet used) device names to attached volumes.
-// If we reuse a previously used name, we may get the volume "attaching" forever.
 // NameAllocator finds available device name, taking into account already
-// assigned device names from ExistingNames map. It tries to find the next
-// device name to the previously assigned one (from previous NameAllocator
-// call), so all available device names are used eventually and it minimizes
-// device name reuse.
+// assigned device names. It tries to find the next unused device name.
 type NameAllocator interface {
 	// GetNext returns a free device name or error when there is no free device
 	// name. Only the device name is returned, e.g. "ba" for "/dev/xvdba".
 	// It's up to the called to add appropriate "/dev/sd" or "/dev/xvd" prefix.
-	GetNext(existingNames ExistingNames) (name string, err error)
+	GetNext(existing []string) (name string, err error)
 }
 
 type nameAllocator struct{}
 
 var _ NameAllocator = &nameAllocator{}
 
-// GetNext gets next available device given existing names that are being used
-// This function iterate through the device names in deterministic order of:
+// GetNext gets next available device name.
+// This function iterates through the device names in deterministic order of:
 //
-//	a ... z, aa ... az
+//	b ... z, aa ... az
 //
 // and return the first one that is not used yet.
-func (d *nameAllocator) GetNext(existingNames ExistingNames) (string, error) {
-	deviceMap := [52]string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "aa", "ab", "ac", "ad", "ae", "af", "ag", "ah", "ai", "aj", "ak", "al", "am", "an", "ao", "ap", "aq", "ar", "as", "at", "au", "av", "aw", "ax", "ay", "az"}
-	for i := 1; i < 52; i++ {
-		name := deviceMap[i]
-		if _, found := existingNames[name]; !found {
+// Note: a is reserved for the root volume.
+func (d *nameAllocator) GetNext(existing []string) (string, error) {
+	deviceMap := [51]string{"b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "aa", "ab", "ac", "ad", "ae", "af", "ag", "ah", "ai", "aj", "ak", "al", "am", "an", "ao", "ap", "aq", "ar", "as", "at", "au", "av", "aw", "ax", "ay", "az"}
+	for _, name := range deviceMap {
+		if !slices.Contains(existing, name) {
 			return name, nil
 		}
 	}

--- a/pkg/cloud/devicemanager/allocator_test.go
+++ b/pkg/cloud/devicemanager/allocator_test.go
@@ -21,9 +21,8 @@ import (
 )
 
 func TestNameAllocator(t *testing.T) {
-	existingNames := map[string]string{}
 	allocator := nameAllocator{}
-
+	existingNames := []string{}
 	expectedNames := "bcdefghijklmnopqrstuvwxyz"
 
 	for i := range expectedNames {
@@ -36,18 +35,18 @@ func TestNameAllocator(t *testing.T) {
 			if actual != expectedName {
 				t.Errorf("test %q: expected %q, got %q", expectedName, expectedName, actual)
 			}
-			existingNames[actual] = ""
+			existingNames = append(existingNames, actual)
 		})
 	}
 }
 
 func TestNameAllocatorError(t *testing.T) {
 	allocator := nameAllocator{}
-	existingNames := map[string]string{}
+	existingNames := []string{} //nolint
 
 	for range 52 {
 		name, _ := allocator.GetNext(existingNames)
-		existingNames[name] = ""
+		existingNames = append(existingNames, name)
 	}
 	name, err := allocator.GetNext(existingNames)
 	if err == nil {

--- a/pkg/cloud/devicemanager/manager.go
+++ b/pkg/cloud/devicemanager/manager.go
@@ -17,218 +17,202 @@ limitations under the License.
 package devicemanager
 
 import (
-	"fmt"
-	"maps"
+	"context"
+	"errors"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
-	"k8s.io/klog/v2"
+	"github.com/samber/lo"
 )
 
-const devPreffix = "/dev/xvd"
+const (
+	devPrefix           = "/dev/xvd"
+	assignedMaxDuration = 15 * time.Minute
+	expirationDuration  = 24 * time.Hour
+)
+
+var (
+	Now         = time.Now
+	ErrNotFound = errors.New("not found")
+)
 
 type Device struct {
-	Instance          *osc.Vm
-	Path              string
-	VolumeID          string
-	IsAlreadyAssigned bool
+	vm           string
+	name         string
+	volume       string
+	fromMappings bool
+	linked       bool
 
-	isTainted   bool
-	releaseFunc func() error
+	assignedAt  time.Time
+	refreshedAt time.Time
 }
 
-func (d *Device) Release(force bool) {
-	if !d.isTainted || force {
-		if err := d.releaseFunc(); err != nil {
-			// FIXME: low level function should never log
-			klog.Errorf("Error releasing device: %v", err)
-		}
-	}
+// MarkAsLinked marks the device as successfully mounted.
+func (d *Device) MarkAsLinked() {
+	d.linked = true
 }
 
-// Taint marks the device as no longer reusable
-func (d *Device) Taint() {
-	d.isTainted = true
+func (d *Device) Linked() bool {
+	return d.linked
+}
+
+func (d *Device) Path() string {
+	return devPrefix + d.name
 }
 
 type DeviceManager interface {
-	// NewDevice retrieves the device if the device is already assigned.
-	// Otherwise it creates a new device with next available device name
-	// and mark it as unassigned device.
-	NewDevice(instance *osc.Vm, volumeID string) (device Device, err error)
+	// AssignDevice assigns a new device to a volume.
+	// If a device has already been assigned, it is returned.
+	AssignDevice(ctx context.Context, vm *osc.Vm, volumeID string) (device *Device, err error)
 
 	// GetDevice returns the device already assigned to the volume.
-	GetDevice(instance *osc.Vm, volumeID string) (device Device)
+	GetDevice(ctx context.Context, vm *osc.Vm, volumeID string) (device *Device, err error)
+
+	Release(ctx context.Context, vm *osc.Vm, volumeID string)
 }
 
 type deviceManager struct {
-	// nameAllocator assigns new device name
 	nameAllocator NameAllocator
-
-	// We keep an active list of devices we have assigned but not yet
-	// attached, to avoid a race condition where we assign a device mapping
-	// and then get a second request before we attach the volume.
-	mux      sync.Mutex
-	inFlight inFlightAttaching
+	mu            sync.Mutex
+	volumes       volumeMap
 }
 
 var _ DeviceManager = &deviceManager{}
 
-// inFlightAttaching represents the device names being currently attached to nodes.
-// A valid pseudo-representation of it would be {"nodeID": {"deviceName: "volumeID"}}.
-type inFlightAttaching map[string]map[string]string
+// volumeMap represents the device names being currently attached to nodes.
+// A valid pseudo-representation of it would be {"nodeID": {"deviceName": "volumeID"}}.
+type volumeMap map[string]*Device
 
-func (i inFlightAttaching) Add(nodeID, volumeID, name string) {
-	attaching := i[nodeID]
-	if attaching == nil {
-		attaching = make(map[string]string)
-		i[nodeID] = attaching
+func (m volumeMap) Add(d *Device) {
+	d.refreshedAt = Now()
+	m[d.volume] = d
+}
+
+func (m volumeMap) Del(volume string) {
+	delete(m, volume)
+}
+
+func (m volumeMap) Get(volume string) (*Device, bool) {
+	dev, found := m[volume]
+	return dev, found
+}
+
+// getDeviceName trims /dev/sd or /dev/xvd from device name
+func getDeviceName(path string) string {
+	name := strings.TrimPrefix(path, "/dev/sd")
+	name = strings.TrimPrefix(name, "/dev/xvd")
+	return name
+}
+
+func (m volumeMap) refresh(vm *osc.Vm) {
+	// remove all previous mappings
+	for vol, dev := range m {
+		if dev.vm != vm.VmId || !dev.fromMappings {
+			continue
+		}
+		delete(m, vol)
 	}
-	attaching[name] = volumeID
+
+	// add mappings
+	for _, blockDevice := range vm.BlockDeviceMappings {
+		name := getDeviceName(blockDevice.DeviceName)
+		if len(name) < 1 || len(name) > 2 {
+			continue
+		}
+		volume := blockDevice.Bsu.VolumeId
+		// delete devices that have been incorrectly assigned to the same name.
+		for vol, dev := range m {
+			if dev.vm == vm.VmId && dev.name == name && dev.volume != volume {
+				delete(m, vol)
+			}
+		}
+		m[volume] = &Device{
+			vm:           vm.VmId,
+			name:         name,
+			volume:       volume,
+			fromMappings: true,
+			linked:       true,
+			refreshedAt:  Now(),
+		}
+	}
+
+	// prune old entries (including for other vm, as nodes might have been deleted)
+	for vol, dev := range m {
+		if !dev.assignedAt.IsZero() && time.Since(dev.assignedAt) > assignedMaxDuration {
+			delete(m, vol)
+		}
+		if !dev.refreshedAt.IsZero() && time.Since(dev.refreshedAt) > expirationDuration {
+			delete(m, vol)
+		}
+	}
 }
 
-func (i inFlightAttaching) Del(nodeID, name string) {
-	delete(i[nodeID], name)
-}
-
-func (i inFlightAttaching) GetNames(nodeID string) map[string]string {
-	return i[nodeID]
-}
-
-func (i inFlightAttaching) GetVolume(nodeID, name string) string {
-	return i[nodeID][name]
+func (m volumeMap) GetUsedNames(vm string) []string {
+	return lo.FilterMap(lo.Values(m), func(d *Device, _ int) (string, bool) {
+		if d.vm != vm {
+			return "", false
+		}
+		return d.name, true
+	})
 }
 
 func NewDeviceManager() DeviceManager {
 	return &deviceManager{
 		nameAllocator: &nameAllocator{},
-		inFlight:      make(inFlightAttaching),
+		volumes:       make(volumeMap),
 	}
 }
 
-func (d *deviceManager) NewDevice(instance *osc.Vm, volumeID string) (Device, error) {
-	d.mux.Lock()
-	defer d.mux.Unlock()
+func (d *deviceManager) AssignDevice(ctx context.Context, vm *osc.Vm, volumeID string) (*Device, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
-	// Get device names being attached and already attached to this instance
-	inUse := d.getDeviceNamesInUse(instance)
+	d.volumes.refresh(vm)
 
-	// Check if this volume is already assigned a device on this machine
-	if path := d.getPath(inUse, volumeID); path != "" {
-		return d.newBlockDevice(instance, volumeID, path, true), nil
+	// if already assigned to the right vm return the assigned device.
+	// if already present, but with another vm, it must have been a missed unlink, reassign,
+	if dev, found := d.volumes.Get(volumeID); found && dev.vm == vm.VmId {
+		return dev, nil
 	}
 
-	nodeID, err := getInstanceID(instance)
-	if err != nil {
-		return Device{}, err
-	}
-
+	// Assign a new name
+	inUse := d.volumes.GetUsedNames(vm.VmId)
 	name, err := d.nameAllocator.GetNext(inUse)
 	if err != nil {
-		return Device{}, fmt.Errorf("could not get a free device name to assign to node %s", nodeID)
+		return nil, err
 	}
 
-	// Add the chosen device and volume to the "attachments in progress" map
-	d.inFlight.Add(nodeID, volumeID, name)
+	dev := &Device{
+		name:       name,
+		vm:         vm.VmId,
+		volume:     volumeID,
+		assignedAt: Now(),
+	}
+	d.volumes.Add(dev)
 
-	return d.newBlockDevice(instance, volumeID, devPreffix+name, false), nil
+	return dev, nil
 }
 
-func (d *deviceManager) GetDevice(instance *osc.Vm, volumeID string) Device {
-	d.mux.Lock()
-	defer d.mux.Unlock()
+func (d *deviceManager) GetDevice(ctx context.Context, vm *osc.Vm, volumeID string) (*Device, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
-	inUse := d.getDeviceNamesInUse(instance)
+	d.volumes.refresh(vm)
 
-	if path := d.getPath(inUse, volumeID); path != "" {
-		return d.newBlockDevice(instance, volumeID, path, true)
+	if dev, found := d.volumes.Get(volumeID); found && dev.vm == vm.VmId {
+		return dev, nil
 	}
 
-	return d.newBlockDevice(instance, volumeID, "", false)
+	return nil, ErrNotFound
 }
 
-func (d *deviceManager) newBlockDevice(instance *osc.Vm, volumeID string, path string, isAlreadyAssigned bool) Device {
-	device := Device{
-		Instance:          instance,
-		Path:              path,
-		VolumeID:          volumeID,
-		IsAlreadyAssigned: isAlreadyAssigned,
+func (d *deviceManager) Release(ctx context.Context, vm *osc.Vm, volumeID string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
 
-		isTainted: false,
+	if dev, found := d.volumes.Get(volumeID); found && dev.vm == vm.VmId {
+		d.volumes.Del(volumeID)
 	}
-	device.releaseFunc = func() error {
-		return d.release(device)
-	}
-	return device
-}
-
-func (d *deviceManager) release(device Device) error {
-	nodeID, err := getInstanceID(device.Instance)
-	if err != nil {
-		return err
-	}
-
-	d.mux.Lock()
-	defer d.mux.Unlock()
-
-	var name string
-	if len(device.Path) > 2 {
-		name = strings.TrimPrefix(device.Path, devPreffix)
-	}
-
-	existingVolumeID := d.inFlight.GetVolume(nodeID, name)
-	if len(existingVolumeID) == 0 {
-		// Attaching is not in progress, so there's nothing to release
-		return nil
-	}
-
-	if device.VolumeID != existingVolumeID {
-		// This actually can happen, because GetNext combines the inFlightAttaching map with the volumes
-		// attached to the instance (as reported by the EC2 API).  So if release comes after
-		// a 10 second poll delay, we might as well have had a concurrent request to allocate a mountpoint,
-		// which because we allocate sequentially is very likely to get the immediately freed volume.
-		return fmt.Errorf("release on device %q assigned to different volume: %q vs %q", device.Path, device.VolumeID, existingVolumeID)
-	}
-
-	// klog.V(5).Infof("Releasing in-process attachment entry: %v -> volume %s", device.Path, device.VolumeID)
-	d.inFlight.Del(nodeID, name)
-
-	return nil
-}
-
-// getDeviceNamesInUse returns the device to volume ID mapping
-// the mapping includes both already attached and being attached volumes
-func (d *deviceManager) getDeviceNamesInUse(instance *osc.Vm) map[string]string {
-	nodeID := instance.VmId
-	inUse := map[string]string{}
-	for _, blockDevice := range instance.BlockDeviceMappings {
-		name := blockDevice.DeviceName
-		// trims /dev/sd or /dev/xvd from device name
-		name = strings.TrimPrefix(name, "/dev/sd")
-		name = strings.TrimPrefix(name, "/dev/xvd")
-
-		if len(name) < 1 || len(name) > 2 {
-			klog.Warningf("Unexpected BSU DeviceName: %q", blockDevice.DeviceName)
-		}
-		inUse[name] = blockDevice.Bsu.VolumeId
-	}
-
-	// klog.V(5).Infof("DeviceNameInUse: APIDevice: %v, CacheDevice: %v", inUse, d.inFlight.GetNames(nodeID))
-	maps.Copy(inUse, d.inFlight.GetNames(nodeID))
-
-	return inUse
-}
-
-func (d *deviceManager) getPath(inUse map[string]string, volumeID string) string {
-	for name, volID := range inUse {
-		if volumeID == volID {
-			return devPreffix + name
-		}
-	}
-	return ""
-}
-
-func getInstanceID(instance *osc.Vm) (string, error) {
-	return instance.VmId, nil
 }

--- a/pkg/cloud/devicemanager/manager_test.go
+++ b/pkg/cloud/devicemanager/manager_test.go
@@ -14,165 +14,133 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package devicemanager
+package devicemanager_test
 
 import (
+	"strconv"
 	"testing"
 
+	"github.com/outscale/osc-bsu-csi-driver/pkg/cloud/devicemanager"
 	"github.com/outscale/osc-sdk-go/v3/pkg/osc"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
-func TestNewDevice(t *testing.T) {
-	testCases := []struct {
-		name               string
-		instanceID         string
-		existingDevicePath string
-		existingVolumeID   string
-		volumeID           string
-	}{
-		{
-			name:               "success: normal",
-			instanceID:         "instance-1",
-			existingDevicePath: "/dev/xvdbc",
-			existingVolumeID:   "vol-1",
-			volumeID:           "vol-2",
-		},
-		{
-			name:               "success: parallel same instance but different volumes",
-			instanceID:         "instance-1",
-			existingDevicePath: "/dev/xvdbc",
-			existingVolumeID:   "vol-1",
-			volumeID:           "vol-4",
-		},
-		{
-			name:               "success: parallel different instances but same volume",
-			instanceID:         "instance-2",
-			existingDevicePath: "/dev/xvdbc",
-			existingVolumeID:   "vol-1",
-			volumeID:           "vol-4",
-		},
-	}
-	// Use a shared DeviceManager to make sure that there are no race conditions
-	dm := NewDeviceManager()
+func TestAssignDevice(t *testing.T) {
+	vm := newFakeInstance("i-foo", "vol-foo", "/dev/xvdbc")
+	t.Run("AssignDevice should assign a new device to a new volume", func(t *testing.T) {
+		dm := devicemanager.NewDeviceManager()
+		dev, err := dm.AssignDevice(t.Context(), vm, "vol-bar")
+		require.NoError(t, err)
+		assert.NotEqual(t, "/dev/xvdbc", dev.Path())
+	})
+	t.Run("AssignDevice should return an already mounted device", func(t *testing.T) {
+		dm := devicemanager.NewDeviceManager()
+		dev, err := dm.AssignDevice(t.Context(), vm, "vol-foo")
+		require.NoError(t, err)
+		assert.Equal(t, "/dev/xvdbc", dev.Path())
+	})
+	t.Run("AssignDevice should reassign the same volume to the same device", func(t *testing.T) {
+		dm := devicemanager.NewDeviceManager()
+		dev1, err := dm.AssignDevice(t.Context(), vm, "vol-bar")
+		require.NoError(t, err)
+		dev2, err := dm.AssignDevice(t.Context(), vm, "vol-bar")
+		require.NoError(t, err)
+		assert.Equal(t, dev1.Path(), dev2.Path())
+	})
+	t.Run("AssignDevice should not assign the same device as a previously assigned device", func(t *testing.T) {
+		dm := devicemanager.NewDeviceManager()
+		dev1, err := dm.AssignDevice(t.Context(), vm, "vol-bar")
+		require.NoError(t, err)
+		dev2, err := dm.AssignDevice(t.Context(), vm, "vol-baz")
+		require.NoError(t, err)
+		assert.NotEqual(t, dev1.Path(), dev2.Path())
+	})
+	t.Run("AssignDevice should reassign to another device if the device has been linked in-between", func(t *testing.T) {
+		dm := devicemanager.NewDeviceManager()
+		dev1, err := dm.AssignDevice(t.Context(), vm, "vol-bar")
+		require.NoError(t, err)
+		assert.NotEqual(t, "/dev/xvdbc", dev1.Path())
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Should fail if instance is nil
-			fakeInstance := newFakeInstance(tc.instanceID, tc.existingVolumeID, tc.existingDevicePath)
-
-			// Should create valid Device with valid path
-			dev1, err := dm.NewDevice(fakeInstance, tc.volumeID)
-			assertDevice(t, dev1, false, err)
-
-			// Devices with same instance and volume should have same paths
-			dev2, err := dm.NewDevice(fakeInstance, tc.volumeID)
-			assertDevice(t, dev2, true /*IsAlreadyAssigned*/, err)
-			if dev1.Path != dev2.Path {
-				t.Fatalf("Expected equal paths, got %v and %v", dev1.Path, dev2.Path)
-			}
-
-			// Should create new Device with the same path after releasing
-			dev2.Release(false)
-			dev3, err := dm.NewDevice(fakeInstance, tc.volumeID)
-			assertDevice(t, dev3, false, err)
-			if dev3.Path != dev1.Path {
-				t.Fatalf("Expected equal paths, got %v and %v", dev1.Path, dev3.Path)
-			}
-			dev3.Release(false)
-		})
-	}
+		vmUpdated := newFakeInstance("i-foo", "vol-baz", dev1.Path())
+		dev2, err := dm.AssignDevice(t.Context(), vmUpdated, "vol-bar")
+		require.NoError(t, err)
+		assert.NotEqual(t, dev1.Path(), dev2.Path())
+	})
+	t.Run("Multiple concurrent requests should assign different devices", func(t *testing.T) {
+		dm := devicemanager.NewDeviceManager()
+		wg := errgroup.Group{}
+		count := 10
+		wg.SetLimit(count)
+		out := make(chan string, count)
+		for i := range count {
+			wg.Go(func() error {
+				dev, err := dm.AssignDevice(t.Context(), vm, "vol-"+strconv.Itoa(i))
+				if err != nil {
+					return err
+				}
+				out <- dev.Path()
+				return nil
+			})
+		}
+		err := wg.Wait()
+		require.NoError(t, err)
+		close(out)
+		paths := lo.ChannelToSlice(out)
+		assert.Len(t, lo.Uniq(paths), count)
+	})
 }
 
 func TestGetDevice(t *testing.T) {
-	testCases := []struct {
-		name     string
-		testFunc func(t *testing.T)
-	}{
-		{
-			name: "success: normal",
-			testFunc: func(t *testing.T) {
-				instanceID := "instance-1"
-				existingDevicePath := "/dev/xvdbc"
-				existingVolumeID := "vol-1"
-				volumeID := "vol-2"
-
-				dm := NewDeviceManager()
-				fakeInstance := newFakeInstance(instanceID, existingVolumeID, existingDevicePath)
-
-				// Should create valid Device with valid path
-				dev1, err := dm.NewDevice(fakeInstance, volumeID)
-				assertDevice(t, dev1, false /*IsAlreadyAssigned*/, err)
-
-				// Devices with same instance and volume should have same paths
-				dev2 := dm.GetDevice(fakeInstance, volumeID)
-				assertDevice(t, dev2, true /*IsAlreadyAssigned*/, err)
-				if dev1.Path != dev2.Path {
-					t.Fatalf("Expected equal paths, got %v and %v", dev1.Path, dev2.Path)
-				}
-			},
-		},
-		{
-			name: "success: device not attached",
-			testFunc: func(t *testing.T) {
-				instanceID := "instance-1"
-				existingDevicePath := "/dev/xvdbc"
-				existingVolumeID := "vol-1"
-				volumeID := "vol-2"
-
-				dm := NewDeviceManager()
-				fakeInstance := newFakeInstance(instanceID, existingVolumeID, existingDevicePath)
-
-				// Devices with same instance and volume should have same paths
-				dev2 := dm.GetDevice(fakeInstance, volumeID)
-				assertDevice(t, dev2, false /*IsAlreadyAssigned*/, nil)
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, tc.testFunc)
-	}
+	vm1 := newFakeInstance("i-foo", "vol-foo", "/dev/xvdbc")
+	vm2 := newFakeInstance("i-bar", "vol-bar", "/dev/xvdbc")
+	t.Run("GetDevice should return a mounted device", func(t *testing.T) {
+		dm := devicemanager.NewDeviceManager()
+		dev, err := dm.GetDevice(t.Context(), vm1, "vol-foo")
+		require.NoError(t, err)
+		assert.Equal(t, "/dev/xvdbc", dev.Path())
+	})
+	t.Run("GetDevice should return an assigned device", func(t *testing.T) {
+		dm := devicemanager.NewDeviceManager()
+		dev1, err := dm.AssignDevice(t.Context(), vm1, "vol-bar")
+		require.NoError(t, err)
+		dev2, err := dm.GetDevice(t.Context(), vm1, "vol-bar")
+		require.NoError(t, err)
+		assert.Equal(t, dev1.Path(), dev2.Path())
+	})
+	t.Run("GetDevice should return an error if volume does not exist", func(t *testing.T) {
+		dm := devicemanager.NewDeviceManager()
+		_, err := dm.GetDevice(t.Context(), vm1, "vol-bar")
+		require.ErrorIs(t, err, devicemanager.ErrNotFound)
+	})
+	t.Run("GetDevice should return an error if volume is mounted on another vm", func(t *testing.T) {
+		dm := devicemanager.NewDeviceManager()
+		_, err := dm.GetDevice(t.Context(), vm2, "vol-foo")
+		require.ErrorIs(t, err, devicemanager.ErrNotFound)
+	})
 }
 
 func TestReleaseDevice(t *testing.T) {
-	testCases := []struct {
-		name               string
-		instanceID         string
-		existingDevicePath string
-		existingVolumeID   string
-		volumeID           string
-	}{
-		{
-			name:               "success: normal",
-			instanceID:         "instance-1",
-			existingDevicePath: "/dev/xvdbc",
-			existingVolumeID:   "vol-1",
-			volumeID:           "vol-2",
-		},
-	}
-
-	dm := NewDeviceManager()
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			fakeInstance := newFakeInstance(tc.instanceID, tc.existingVolumeID, tc.existingDevicePath)
-
-			// Should get assigned Device after releasing tainted device
-			dev, err := dm.NewDevice(fakeInstance, tc.volumeID)
-			assertDevice(t, dev, false /*IsAlreadyAssigned*/, err)
-			dev.Taint()
-			dev.Release(false)
-			dev2 := dm.GetDevice(fakeInstance, tc.volumeID)
-			assertDevice(t, dev2, true /*IsAlreadyAssigned*/, nil)
-			if dev.Path != dev2.Path {
-				t.Fatalf("Expected device to be already assigned, got unassigned")
-			}
-
-			// Should release tainted device if force=true is passed in
-			dev2.Release(true)
-			dev3 := dm.GetDevice(fakeInstance, tc.volumeID)
-			assertDevice(t, dev3, false /*IsAlreadyAssigned*/, nil)
-		})
-	}
+	vm1 := newFakeInstance("i-foo", "vol-foo", "/dev/xvdbc")
+	vm2 := newFakeInstance("i-bar", "vol-bar", "/dev/xvdbc")
+	t.Run("ReleaseDevice should release an assigned device", func(t *testing.T) {
+		dm := devicemanager.NewDeviceManager()
+		_, err := dm.AssignDevice(t.Context(), vm1, "vol-bar")
+		require.NoError(t, err)
+		dm.Release(t.Context(), vm1, "vol-bar")
+		_, err = dm.GetDevice(t.Context(), vm1, "vol-bar")
+		require.ErrorIs(t, err, devicemanager.ErrNotFound)
+	})
+	t.Run("ReleaseDevice should not release a device from another vm", func(t *testing.T) {
+		dm := devicemanager.NewDeviceManager()
+		_, err := dm.GetDevice(t.Context(), vm2, "vol-bar")
+		require.NoError(t, err)
+		dm.Release(t.Context(), vm1, "vol-bar")
+		_, err = dm.GetDevice(t.Context(), vm2, "vol-bar")
+		require.NoError(t, err)
+	})
 }
 
 func newFakeInstance(instanceID, volumeID, devicePath string) *osc.Vm {
@@ -184,15 +152,5 @@ func newFakeInstance(instanceID, volumeID, devicePath string) *osc.Vm {
 				Bsu:        osc.BsuCreated{VolumeId: volumeID},
 			},
 		},
-	}
-}
-
-func assertDevice(t *testing.T, d Device, assigned bool, err error) {
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-
-	if d.IsAlreadyAssigned != assigned {
-		t.Fatalf("Expected IsAlreadyAssigned to be %v, got %v", assigned, d.IsAlreadyAssigned)
 	}
 }


### PR DESCRIPTION
## Description

When multiple volumes are simultaneously published on the same node, the second volume might be assigned the same device as the first request.

```
┌───────────────────────┐                            
│ List volumes attached │                            
│       to VM (none)    │                            
└──────────┬────────────┘                            
           │                                         
┌──────────▼────────────┐                            
│ Assign device letter  │                            
│        (xvda)         │                            
└───────────────────────┘                            
           │                ┌───────────────────────┐
┌──────────▼────────────┐   │                       │
│  Link volume to VM    │   │ List volumes attached │
└──────────┬────────────┘   │       to VM (none)    │
           │                │                       │
┌──────────▼────────────┐   └──────────┬────────────┘
│ Release xvda          │              │             
└───────────────────────┘   ┌──────────▼────────────┐
                            │ Assign device letter  │
                            │        (xvda)         │
                            └───────────────────────┘
                                       │             
                            ┌──────────▼────────────┐
                            │  Link volume to VM    │
                            └──────────┬────────────┘
                                       │             
                            ┌──────────▼────────────┐
                            │ Release xvda          │
                            └───────────────────────┘
```

This race would generate `9004`/`ErrorDeviceInUse` errors in `LinkVolume` calls:
```
{Errors:[{Type:ResourceConflict,Details:,Code:9004}],ResponseContext:{RequestId:xxx}}
```
There are two possible fixes:
* add a lock before listing volumes (released after the device linking has been confirmed), this would ensure that the second request knows that xvda has been used before assigning a device letter
* do not release the device letter after having linked the volume

The first fix is simpler to implement, as the device allocator would not need to store volumes in memory, but the lock would be much longer.

To avoid reducing throughput, the second approach has been chosen.

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
